### PR TITLE
Fixes bug where the string 'error' may be in Query response body, but…

### DIFF
--- a/TEST.md
+++ b/TEST.md
@@ -63,7 +63,7 @@ pytest --cov-report term-missing --cov -v e3db
 # Build Docker containers
 
 ```bash
-docker build -t tozny/e3db-python:debian .
+docker build -t tozny/e3db-python .
 ```
 
 ## Run Docker container for testing
@@ -71,9 +71,5 @@ docker build -t tozny/e3db-python:debian .
 This container was built in the previous step, and will have the current code base in the repo running inside it. It is currently necessary to re-build the docker container for code changes due to the python `setuptools` configuration. This typically takes 2 to 3 minutes. After the above build step, you can run the container with the following command:
 
 ```bash
-docker run -it --rm \
-  --entrypoint=sh \
-  -e REGISTRATION_TOKEN=<TOKEN> \
-  -e DEFAULT_API_URL=<URL> \
-  tozny/e3db-python sh
+docker run -it --rm --entrypoint=sh -e REGISTRATION_TOKEN=<TOKEN> -e DEFAULT_API_URL=<URL> tozny/e3db-python sh
 ```

--- a/TEST.md
+++ b/TEST.md
@@ -71,5 +71,5 @@ docker build -t tozny/e3db-python .
 This container was built in the previous step, and will have the current code base in the repo running inside it. It is currently necessary to re-build the docker container for code changes due to the python `setuptools` configuration. This typically takes 2 to 3 minutes. After the above build step, you can run the container with the following command:
 
 ```bash
-docker run -it --rm --entrypoint=sh -e REGISTRATION_TOKEN=<TOKEN> -e DEFAULT_API_URL=<URL> tozny/e3db-python sh
+docker run -it --rm --entrypoint=sh -e REGISTRATION_TOKEN=<TOKEN> -e DEFAULT_API_URL=<URL> tozny/e3db-python
 ```

--- a/e3db/client.py
+++ b/e3db/client.py
@@ -879,7 +879,7 @@ class Client:
         """
         url = self.__get_url('v1', 'storage', 'search')
         response = requests.post(url=url, json=query.to_json(), auth=self.e3db_auth)
-        if 'error' in response.text:
+        if 'error' in response.json():
             # we had an error, return this to user
             raise QueryError(response.json()['error'])
         self.__response_check(response)

--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,5 @@
 from setuptools import setup, find_packages
-version = "1.1.1"
+version = "1.1.2"
 setup(
   name="e3db",
   version=version,


### PR DESCRIPTION
… not indicate an E3DB error. For example, a record type with type 'errorTest' would be caught in the old error handling, and then wrongly throw an erorr when one did not exists. This code change ensures that only the json response 'error' field will be looked at, rather than the entire Query response body.