### PR TITLE
Fix re-authorizer bug

### DIFF
--- a/e3db/client.py
+++ b/e3db/client.py
@@ -281,8 +281,9 @@ class Client:
         None
         """
 
-        ak_cache_key = (writer_id, user_id, record_type)
-        self.ak_cache[ak_cache_key] = ak
+        if use_cache:
+            ak_cache_key = (writer_id, user_id, record_type)
+            self.ak_cache[ak_cache_key] = ak
 
         reader_key = self.__client_key(reader_id)
         nonce = Crypto.random_nonce()

--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,5 @@
 from setuptools import setup, find_packages
-version = "1.1.2"
+version = "1.1.3"
 setup(
   name="e3db",
   version=version,


### PR DESCRIPTION
* Fixes bug where re-authorizing an existing authorizer caused a crash
* Fixes issue of using AK cache during authorizer methods where cached AKS may be used, resulting in different states between the server and client in certain circumstances

Once approved, an engineer will need to tag this release, and push it to PyPi for distribution.