### PR TITLE
Upgrade to new class to fix inproper get/set

### DIFF
--- a/e3db/client.py
+++ b/e3db/client.py
@@ -822,7 +822,7 @@ class Client:
         last_index : int
             Retrieve records from this index onwards. Starts at 0 to return all.
             Useful for retrieving records in 'batches'. Exposed to user through
-            the QueryResult.get_after_index() method.
+            the QueryResult.after_index method.
 
         Returns
         -------

--- a/e3db/types/query.py
+++ b/e3db/types/query.py
@@ -236,21 +236,6 @@ class Query(object):
         """
         return self.__include_all_writers
 
-    def get_after_index(self):
-        """
-        Get after_index of records returned from the Query.
-
-        Parameters
-        ----------
-        None
-
-        Returns
-        -------
-        int
-            After index returned from the Query after running against the
-            E3DB server.
-        """
-        return self.__after_index
 
     def to_json(self):
         """

--- a/e3db/types/query.py
+++ b/e3db/types/query.py
@@ -1,7 +1,7 @@
 import uuid
 
 
-class Query():
+class Query(object):
 
     def __init__(self, count, after_index=0, include_data=False,
             writer_ids=None, user_ids=None, record_ids=None, content_types=None,

--- a/e3db/types/query_result.py
+++ b/e3db/types/query_result.py
@@ -101,19 +101,3 @@ class QueryResult(object):
         """
 
         return len(self.__records)
-
-    def get_after_index(self):
-        """
-        Get after_index of records returned from the Query.
-
-        Parameters
-        ----------
-        None
-
-        Returns
-        -------
-        int
-            After index returned from the Query after running against the
-            E3DB server.
-        """
-        return self.__query.get_after_index()

--- a/e3db/types/query_result.py
+++ b/e3db/types/query_result.py
@@ -2,7 +2,7 @@ from query import Query
 from record import Record
 
 
-class QueryResult():
+class QueryResult(object):
 
     def __init__(self, query, records):
         """

--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,5 @@
 from setuptools import setup, find_packages
-version = "1.2.1"
+version = "1.3.0"
 setup(
   name="e3db",
   version=version,


### PR DESCRIPTION
Makes Query and QueryResult inherit from object (new class)
Allows the user to use results.after_index or results.get_after_index()
Makes the getters and setters work properly in python2