### PR TITLE
[WASH-362] Features/v2-query

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:2.7-alpine
+FROM python:3.7-alpine
 
 RUN apk add --no-cache gcc musl-dev libffi-dev make openssl-dev
 RUN mkdir -p /src

--- a/Makefile
+++ b/Makefile
@@ -18,3 +18,15 @@ help:
 # "make mode" option.  $(O) is meant as a shortcut for $(SPHINXOPTS).
 %: Makefile
 	@$(SPHINXBUILD) -M $@ "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)
+
+dep:
+	pip install pytest pytest-cov
+
+docker-build:
+	docker build ./ -f LocalDevDockerfile -t tozny/e3db-python 
+
+integration-test:
+	docker run -it --rm --entrypoint=sh -e REGISTRATION_TOKEN=${REGISTRATION_TOKEN} -e DEFAULT_API_URL=${DEFAULT_API_URL} tozny/e3db-python
+
+test:
+	pytest --cov-report term-missing --cov -v ./e3db

--- a/Makefile
+++ b/Makefile
@@ -19,12 +19,6 @@ help:
 %: Makefile
 	@$(SPHINXBUILD) -M $@ "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)
 
-dep:
-	pip install pytest pytest-cov
-
-docker-build:
-	docker build ./ -f LocalDevDockerfile -t tozny/e3db-python 
-
 integration-test:
 	docker run -it --rm --entrypoint=sh -e REGISTRATION_TOKEN=${REGISTRATION_TOKEN} -e DEFAULT_API_URL=${DEFAULT_API_URL} tozny/e3db-python
 

--- a/e3db/client.py
+++ b/e3db/client.py
@@ -913,12 +913,13 @@ class Client:
         results = response['results']
         last_index = response['last_index']
         search_id = response['search_id']
+        total_results = response['total_results']
 
         if results is None:
-            return SearchResult(query, [], last_index, search_id)
+            return SearchResult(query, [], last_index, total_results, search_id)
 
         records = self.__parse_results(results, query.include_data)
-        qr = SearchResult(query, records, last_index, search_id)
+        qr = SearchResult(query, records, last_index, total_results, search_id)
         return qr
 
     def __search(self, query):
@@ -938,7 +939,7 @@ class Client:
         url = self.__get_url('v2', 'search')
         response = requests.post(url=url, json=query.to_json(), auth=self.e3db_auth)
         self.__response_check(response)
-        json = response.json() # Search Service does not return error message, just status codes
+        json = response.json() # server does not return error message, just status codes
         return json
 
     def __parse_results(self, results, include_data):

--- a/e3db/client.py
+++ b/e3db/client.py
@@ -889,6 +889,26 @@ class Client:
         return QueryError("An unexpected response occurred, and no results were returned")
 
     def search(self, query):
+        """
+        Public Method to perform improved search request for E3db records according to the query provided.
+
+        Requires a Search object to perform the Query. Construction and Execution is as follows:
+
+        search_this = Search().Match(records=[some_params,...]).Exclude(writers=[omit_this,...])
+        search_result = client.search(search_this) 
+
+        For more information see the documentation of the Search Object or Tests.
+
+        Parameters
+        ----------
+        query : Search
+            Object that contains the information to search for.
+        
+        Returns
+        -------
+        SearchResult
+            Result of a valid response from E3DB.
+        """
         response = self.__search(query)
         results = response['results']
         last_index = response['last_index']
@@ -902,6 +922,19 @@ class Client:
         return qr
 
     def __search(self, query):
+        """
+        Private Method to send search request to E3DB and return a json response.
+        
+        Parameters
+        ----------
+        query: Search
+            Search object represents the query made to the E3DB.
+        
+        Returns
+        -------
+        dict
+            response from the server as json (dict).
+        """
         url = self.__get_url('v2', 'search')
         response = requests.post(url=url, json=query.to_json(), auth=self.e3db_auth)
         self.__response_check(response)
@@ -909,6 +942,26 @@ class Client:
         return json
 
     def __parse_results(self, results, include_data):
+        """
+        Private Method to parse the response of a search v1 or v2 request.
+
+        A Query/Search Response comes in as json and is abstracted into the
+        Meta and Record class. If data is included in the response (result_data != None),
+        then the data is decrypted with the provided access_key.
+
+        Parameters
+        ----------
+        results: dict[string]object (json)
+            json response from PDS
+
+        include_data: bool
+            Flag to indicate if data is included in the response, taken from the Query.
+        
+        Returns
+        ----------
+        [Records]
+            List of Record Objects
+        """
         records = []
         for result in results:
             result_meta = result['meta']

--- a/e3db/tests/test_search_integration.py
+++ b/e3db/tests/test_search_integration.py
@@ -13,12 +13,17 @@ from ..types import ClientDetails
 
 api_url = os.environ["DEFAULT_API_URL"]
 token = os.environ["REGISTRATION_TOKEN"]
+### Variables required for internal testing
+local_api_url = os.environ["LOCAL_API_URL"]
+local_boot_key = os.environ["LOCAL_BOOT_KEY"]
+local_boot_secret = os.environ["LOCAL_BOOT_SECRET"]
+local_register = os.environ["USE_LOCAL_REGISTER"]
 
 class TestSearchIntegration():
     @classmethod
     def register_client(self):
         client1_public_key, client1_private_key = e3db.Client.generate_keypair()
-        client1_name = "client_{0}".format(binascii.hexlify(os.urandom(16)))
+        client1_name = "email_{0}@tozny.com".format(time.time())
         test_client1 = e3db.Client.register(token, client1_name, client1_public_key, api_url=api_url)
         client1_api_key_id = test_client1.api_key_id
         client1_api_secret = test_client1.api_secret
@@ -34,9 +39,87 @@ class TestSearchIntegration():
         )
         self.client1 = e3db.Client(client1_config())
 
+        client2_public_key, client2_private_key = e3db.Client.generate_keypair()
+        client2_name = "email_{0}@tozny.com".format(time.time())
+        test_client2 = e3db.Client.register(token, client2_name, client2_public_key, api_url=api_url)
+        client2_api_key_id = test_client2.api_key_id
+        client2_api_secret = test_client2.api_secret
+        client2_id = test_client2.client_id
+
+        client2_config = e3db.Config(
+            client2_id,
+            client2_api_key_id,
+            client2_api_secret,
+            client2_public_key,
+            client2_private_key,
+            api_url=api_url 
+        )
+        self.client2 = e3db.Client(client2_config())
+
+    @classmethod
+    def internal_register_client(self):
+        """
+        Method for local testing only
+        """
+        client1_public_key, client1_private_key = e3db.Client.generate_keypair()
+
+        url = "{0}/{1}/{2}/{3}".format(local_api_url, 'v1', 'storage', 'clients')
+        email = "email_{0}@tozny.com".format(time.time())
+        payload = {
+            'email': email,
+            'public_key': {
+                'curve25519': client1_public_key
+            },
+            'private_key': {
+                'curve25519': client1_private_key
+            }
+        }
+        bootstrapAuth = E3DBAuth(local_boot_key, local_boot_secret, local_api_url)
+        response = requests.post(url=url, json=payload, auth=bootstrapAuth)
+        client_info = response.json()
+
+        client1_config = e3db.Config(
+            client_info["client_id"],
+            client_info["api_key_id"],
+            client_info["api_secret"],
+            client1_public_key,
+            client1_private_key,
+            api_url=local_api_url 
+        )
+        self.client1 = e3db.Client(client1_config())
+
+    @classmethod
+    def wait_for_index_record(self, retries):
+        """
+        Instead of sleeping, delay tests until the latest record is found.
+        """
+        found = False
+        wait = 1 
+        record_id = self.encrypted_file_meta.record_id
+        while not found and retries >= 0:
+            q = e3db.types.Search().match(record=[record_id])
+            results = self.client2.search(q)
+            if len(results) != 1:
+                time.sleep(wait)
+                wait <<= 1 # double the time waited
+                retries -= 1
+            else:
+                return True
+        return False
+
+    @classmethod
+    def __help_create_large_file(self, fileName):
+        with open(fileName, "wb+") as f:
+            for _ in range(1, 1024):
+                f.write(b'b' * 1024)
+        return os.path.isfile(fileName)
+
     @classmethod
     def setup_class(self):
-        self.register_client()
+        if local_register == "true":
+            self.internal_register_client()
+        else:
+            self.register_client()
         self.record_type = "SDK_integration_tests"
         self.record1 = self.client1.write(self.record_type, 
                                             {'time': str(time.time())}, 
@@ -46,12 +129,18 @@ class TestSearchIntegration():
                                             })
 
         self.record2 = self.client1.write(self.record_type, 
-                                            {'time': str(time.time())} )
-        time.sleep(1) # Time needed for indexer to process record
+                                            {'time': str(time.time())})
+        fileName = "large_file.txt"
+        didCreate = self.__help_create_large_file(fileName)
+        if not didCreate:
+            pytest.exit("could not create large_file.txt")
+        self.large_record_type = "large_files"
+        self.encrypted_file_meta = self.client2.write_file(self.large_record_type, fileName, {"large":"test"})
+        if not self.wait_for_index_record(retries=5):
+            pytest.exit("Timeout while waiting for indexed record")
 
     def test_v2_search_write_and_query(self):
         record1_id = self.record1.meta.record_id
-        print(record1_id)
         q = e3db.types.Search(include_data=True).match(record=[record1_id])
         results = self.client1.search(q)
         for r in results:
@@ -67,13 +156,17 @@ class TestSearchIntegration():
             print(r.to_json())
         assert(len(results) == 0)
 
-    def test_v2_exclude_only_record(self):
-        q = e3db.types.Search().match(record_type=[self.record_type]).exclude(record=[self.record1.meta.record_id])
+    def test_v2_other_client_finds_nothing(self):
+        q = e3db.types.Search(count=1000).match(record_type=[self.record_type]).exclude(record=[self.record1.meta.record_id])
         results = self.client1.search(q)
         assert(len(results)==1)
 
+        q = e3db.types.Search().match(record_type=[self.record_type])
+        results = self.client2.search(q)
+        assert(len(results)==0)
+
     def test_v2_search_fuzzy(self):
-        q = e3db.types.Search(include_data=True).match(strategy="FUZZY",values=["veryveryfunny"])
+        q = e3db.types.Search(include_data=True, count=1000).match(strategy="FUZZY",values=["veryveryfunny"])
         results = self.client1.search(q)
         assert(len(results)==1)
 
@@ -124,5 +217,22 @@ class TestSearchIntegration():
             print("record:")
             print(r.to_json())
         assert(len(results) == 1)
+    
+    def test_v1_file_meta(self):
+        print("encrypted record id", self.encrypted_file_meta.record_id)
+        results = self.client2.query(record=[self.encrypted_file_meta.record_id])
+        assert(len(results) == 1)
+        for r in results:
+            print("returned", r.meta.to_json())
+            print("expected", self.encrypted_file_meta.to_json())
+            assert(r.data == {}) # Large Files come back with no Data
+            assert(r.meta.file_meta is not None)
+            assert(r.meta.file_meta._checksum == self.encrypted_file_meta.checksum)
 
-
+    def test_v2_file_meta(self):
+        q = e3db.types.Search().match(record=[self.encrypted_file_meta.record_id])
+        results = self.client2.search(q)
+        assert(len(results) == 1)
+        for r in results:
+            assert(r.meta.file_meta is not None)
+            assert(r.meta.file_meta._checksum == self.encrypted_file_meta.checksum)

--- a/e3db/tests/test_search_integration.py
+++ b/e3db/tests/test_search_integration.py
@@ -1,0 +1,128 @@
+import e3db
+import os
+import binascii
+import pytest
+import time
+import e3db.types
+import hashlib
+import requests
+from datetime import datetime
+from datetime import timedelta
+from ..auth import E3DBAuth
+from ..types import ClientDetails
+
+api_url = os.environ["DEFAULT_API_URL"]
+token = os.environ["REGISTRATION_TOKEN"]
+
+class TestSearchIntegration():
+    @classmethod
+    def register_client(self):
+        client1_public_key, client1_private_key = e3db.Client.generate_keypair()
+        client1_name = "client_{0}".format(binascii.hexlify(os.urandom(16)))
+        test_client1 = e3db.Client.register(token, client1_name, client1_public_key, api_url=api_url)
+        client1_api_key_id = test_client1.api_key_id
+        client1_api_secret = test_client1.api_secret
+        client1_id = test_client1.client_id
+
+        client1_config = e3db.Config(
+            client1_id,
+            client1_api_key_id,
+            client1_api_secret,
+            client1_public_key,
+            client1_private_key,
+            api_url=api_url 
+        )
+        self.client1 = e3db.Client(client1_config())
+
+    @classmethod
+    def setup_class(self):
+        self.register_client()
+        self.record_type = "SDK_integration_tests"
+        self.record1 = self.client1.write(self.record_type, 
+                                            {'time': str(time.time())}, 
+                                            {'hello':'toznians',
+                                            'regexp':'toznywebsite',
+                                            'fuzzy':'veryveryfuzzy'
+                                            })
+
+        self.record2 = self.client1.write(self.record_type, 
+                                            {'time': str(time.time())} )
+        time.sleep(1) # Time needed for indexer to process record
+
+    def test_v2_search_write_and_query(self):
+        record1_id = self.record1.meta.record_id
+        print(record1_id)
+        q = e3db.types.Search(include_data=True).match(record=[record1_id])
+        results = self.client1.search(q)
+        for r in results:
+            print("record:")
+            print(r.to_json())
+        assert(len(results) == 1)
+
+    def test_v2_search_returns_nothing(self):
+        q = e3db.types.Search(include_data=True).match(values=["ladsfkjadsklfjgarbagefdjsklafjkdljsaf"])
+        results = self.client1.search(q)
+        for r in results:
+            print("record:")
+            print(r.to_json())
+        assert(len(results) == 0)
+
+    def test_v2_exclude_only_record(self):
+        q = e3db.types.Search().match(record_type=[self.record_type]).exclude(record=[self.record1.meta.record_id])
+        results = self.client1.search(q)
+        assert(len(results)==1)
+
+    def test_v2_search_fuzzy(self):
+        q = e3db.types.Search(include_data=True).match(strategy="FUZZY",values=["veryveryfunny"])
+        results = self.client1.search(q)
+        assert(len(results)==1)
+
+    def test_v2_invalid_range(self):
+        record1_id = self.record1.meta.record_id
+        q = e3db.types.Search(include_data=True).match(record=[record1_id]).range(before=datetime.now(), after=datetime.now())
+        results = self.client1.search(q)
+        assert(len(results)==0)
+
+    def test_v2_valid_range(self):
+        record1_id = self.record1.meta.record_id
+        q = e3db.types.Search(include_data=True).match(record=[record1_id]).range(zone="PST", before=datetime.now()+timedelta(hours=1), after=datetime.now()+timedelta(hours=-1))
+        results = self.client1.search(q)
+        assert(len(results)==2)
+
+    def test_v2_multi_match(self):
+        record1_id = self.record1.meta.record_id
+        record2_id = self.record2.meta.record_id
+        q = e3db.types.Search().match(record=[record1_id]).match(record=[record2_id])
+        results = self.client1.search(q)
+        assert(len(results)==2)
+
+    def test_v2_multi_and_match(self):
+        record1_id = self.record1.meta.record_id
+        record2_id = self.record2.meta.record_id
+        q = e3db.types.Search().match(condition="AND", record=[record1_id, record2_id])
+        results = self.client1.search(q)
+        assert(len(results)==0)
+
+    def test_v2_receive_data(self):
+        record1_id = self.record1.meta.record_id
+        q = e3db.types.Search(include_data=True).match(record=[record1_id])
+        results = self.client1.search(q)
+        assert(len(results)==1)
+        for r in results:
+            assert(r.data is not None)
+
+        q = e3db.types.Search(include_data=False).match(record=[record1_id])
+        results = self.client1.search(q)
+        assert(len(results)==1)
+        for r in results:
+            assert(r.data is None)
+
+    def test_v2_search_regexp(self):
+        q = e3db.types.Search(include_data=True).match(strategy="REGEXP", values=['tozny.*'])
+        results = self.client1.search(q)
+        for r in results:
+            print("record:")
+            print(r.to_json())
+        assert(len(results) == 1)
+
+

--- a/e3db/types/__init__.py
+++ b/e3db/types/__init__.py
@@ -8,3 +8,7 @@ from .query import Query
 from .record import Record
 from .authorizer_policy import AuthorizerPolicy
 from .file import File
+from .search_result import SearchResult
+from .search import Search
+from .search import Params
+from .search import Range

--- a/e3db/types/file.py
+++ b/e3db/types/file.py
@@ -66,7 +66,7 @@ class File():
         self.__size = int(size)
         # optional, as some get set by the server
         # set these to None if they are not included when init is called.
-        if record_id is not None:
+        if record_id is not None and not isinstance(record_id, uuid.UUID):
             self.__record_id = uuid.UUID(record_id)
         else:
             self.__record_id = None

--- a/e3db/types/file_meta.py
+++ b/e3db/types/file_meta.py
@@ -1,0 +1,78 @@
+
+
+class FileMeta(object):
+    def __init__(self, size, compression, checksum, file_name=None, file_url=None):
+
+        """
+        Initialize the FileMeta class.
+        Only returned if the record is associated with a Large File.
+
+        Parameters
+        ----------
+        file_name: str
+            Name of the large file that was uploaded
+
+        size: int
+            Size of the encrypted file, in bytes, including E3DB Header information
+
+        compression: str
+            The type of compression the file is using, before encryption. Reserved for future use.
+
+        checksum: str
+            Base64 encoded MD5 Checksum of the Encrypted File, including E3DB Header information
+
+        file_url: str
+            Optional. Signed url used for PUT/GET to storage server
+
+
+        Returns
+        -------
+        FileMeta
+        """
+        self._file_url = file_url
+        self._file_name = file_name
+        self._size = size
+        self._compression = compression
+        self._checksum = checksum
+
+    def __remove_empty(self, serialize):
+        """
+        Parameters
+        ----------
+        serialize: dict
+            Dictionary to remove empty elements from
+
+        Returns
+        -------
+        dict
+            Dictionary with empty elements removed
+        """
+        for key, value in list(serialize.items()):
+            if isinstance(value, dict):
+                self.__remove_empty(value)
+            elif value is None or value == 'None':
+                del serialize[key]
+        return serialize
+
+    def to_json(self):
+        """
+        Serialize the configuration as JSON-style object.
+
+        Parameters
+        ----------
+        None
+
+        Returns
+        -------
+        dict
+            JSON-style document containing the FileMeta elements.
+        """
+        to_serialize = {
+            'file_url': str(self._file_url),
+            'file_name': str(self._file_name),
+            'checksum': str(self._checksum),
+            'compression': str(self._compression),
+            'size': int(self._size) if self._size is not None else -1
+        }
+        return self.__remove_empty(to_serialize)
+

--- a/e3db/types/meta.py
+++ b/e3db/types/meta.py
@@ -1,4 +1,5 @@
 from datetime import datetime
+from .file_meta import FileMeta
 import uuid
 
 
@@ -49,6 +50,15 @@ class Meta():
             self.__last_modified = datetime.strptime(json['last_modified'], '%Y-%m-%d %H:%M:%S.%f') if 'last_modified' in json else None
 
         self.__version = json['version'] if 'version' in json else None
+
+        self.__file_meta = None
+        if json.get('file_meta') is not None:
+            self.__file_meta = FileMeta(checksum=json['file_meta'].get('checksum'), 
+                                compression=json['file_meta'].get('compression'),
+                                size=int(json['file_meta'].get('size', "-1")), 
+                                file_url=json['file_meta'].get('file_url'),
+                                file_name=json['file_meta'].get('file_name')
+                                )
 
     # writer_id getters and setters
     @property
@@ -252,6 +262,19 @@ class Meta():
         """
         return self.__version
 
+    # file_meta getter
+    @property
+    def file_meta(self):
+        """
+        Get file_meta of record if it exists
+        
+        Returns
+        -------
+        File
+            File meta information returned when a record was uploaded with Large Files or None
+        """
+        return self.__file_meta
+
     def to_json(self):
         """
         Serialize the configuration as JSON-style object.
@@ -274,7 +297,8 @@ class Meta():
             'plain': self.__plain,
             'created': str(self.__created),
             'last_modified': str(self.__last_modified),
-            'version': str(self.__version)
+            'version': str(self.__version),
+            'file_meta': None if self.__file_meta is None else self.__file_meta.to_json()
         }
 
         # remove None (JSON null) objects

--- a/e3db/types/search.py
+++ b/e3db/types/search.py
@@ -11,6 +11,40 @@ class Search(object):
         It is exposed through the e3db.Client.search method.
 
         Parameters
+        ----------
+        last_index : int, optional
+            Where to start the query at. E3DB will return an index which indicates
+            where the  query left off. Another query can be executed including this last_index, and 
+            it will pick off where the other left off (the default is 0, which starts from the beginning).
+
+        count : int, optional
+            How many records to include minimum of 1 and up to a maximum of 1000 (the default is 50).
+            Based on the current version, the resulting query might return less than this count, even if
+            there are more records available. The query will need to be re-run with the corresponding last_index.
+
+        include_all_writers : bool, optional
+            Whether or not to include all writers, or just the writer_id of the 
+            (the default is False).
+
+        include_data : bool, optional
+            Whether to include data, or just meta data when retrieving the
+            E3DB records (the default is False).
+
+        match : [Params], optional
+            A list of Search Param objects to Match when querying for Records
+            (the default is None, which matches all records).
+
+        exclude : [Params], optional
+            A list of Search Param objects to Exclude when querying for Records
+            (the default is None, which matches no records excluding nothing).
+
+        range : Range, optional
+            A Search Range object to filter results based on created or last_modified time
+            (the default is None, which removes any time filter.).
+
+        Returns
+        -------
+        Search
         """
         self.__next_token = int(last_index)
         self.__limit = int(count)
@@ -20,17 +54,99 @@ class Search(object):
         self.__exclude = exclude if exclude else []
         self.__range = None
         
+    @property
+    def matches(self):
+        """
+        Get list of Params on which to match.
+        
+        Returns
+        -------
+        [Params]
+            List of Match Parameters
+        """
+        return self.__match
+
+    @matches.setter
+    def matches(self, p):
+        """
+        Set list of Params on which to match. 
+        Overrides current Match Params.
+
+        Parameters
+        ----------
+        p: [Params]
+            Parameters to search on
+
+        Returns
+        -------
+        None
+        """
+        self.__match = p
+
+    @property
+    def excludes(self):
+        """
+        Get list of Params on which to exclude.
+        
+        Returns
+        -------
+        [Params]
+            List of Exclude Parameters
+        """
+        return self.__exclude
+
+    @excludes.setter
+    def excludes(self, p):
+        """
+        Set list of Params on which to exclude. 
+        Overrides current Match Params.
+
+        Parameters
+        ----------
+        p: [Params]
+            Parameters to search on
+
+        Returns
+        -------
+        None
+        """
+        self.__exclude = p
+
     def append_match(self, p):
+        """
+        Add to list of Params on which to Match
+
+        Parameters
+        ----------
+        p : Param
+             Parameter to add to Match list
+
+        Returns
+        -------
+        None
+        """
         self.__match.append(p)
 
     def append_exclude(self, p):
+        """
+        Add to list of Params on which to Exclude
+
+        Parameters
+        ----------
+        p : Param
+             Parameter to add to Exclude list
+
+        Returns
+        -------
+        None
+        """
         self.__exclude.append(p)
 
     # count getters
     @property
     def count(self):
         """
-        Get count of Query.
+        Get count of Search.
 
         Parameters
         ----------
@@ -47,7 +163,7 @@ class Search(object):
     @property
     def after_index(self):
         """
-        Get after_index of Query.
+        Get after_index of Search.
 
         Parameters
         ----------
@@ -56,14 +172,14 @@ class Search(object):
         Returns
         -------
         int
-            Get after_index of the Query.
+            Get after_index of the Search.
         """
         return self.__next_token
 
     @after_index.setter
     def after_index(self, value):
         """
-        Set after_index of QueryResult
+        Set after_index of SearchResult.
 
         Parameters
         ----------
@@ -80,7 +196,7 @@ class Search(object):
     @property
     def include_data(self):
         """
-        Get included_data of Query.
+        Get included_data of Search.
 
         Parameters
         ----------
@@ -122,7 +238,7 @@ class Search(object):
         Returns
         -------
         dict
-            JSON-style document containing the Query elements.
+            JSON-style document containing the Search elements.
         """
         return {
             "limit": int(self.__limit),
@@ -135,16 +251,138 @@ class Search(object):
         }
 
     def match(self, condition="OR", strategy="EXACT", writer=[], record=[], user=[], record_type=[], keys=[], values=[], plain=None):
+        """
+        Public method to construct Query Params on which to Match(select) when searching for E3DB records.
+
+        Appends to the List of Match Parameters in the Search Object.
+        Independent Match Parameters are OR-ed together. 
+
+        Parameters
+        ----------
+        condition : str, optional
+            "OR|AND" (the default is "OR")
+            Provided parameters are either OR-ed or AND-ed together based on the condition provided.
+
+        strategy : str, optional
+            "EXACT|FUZZY|WILDCARD|REGEXP" (the default is "EXACT")
+            Determines the strategy when matching the parameters provided.
+
+        writer : list, optional
+            List of writer ids to filter on (the default is [], which matches all)
+
+        record : list, optional
+            List of reader ids to filter on (the default is [], which matches all)
+
+        user : list, optional
+            List of user ids to filter on (the default is [], which matches all)
+
+        record_type : list, optional
+            List of record_types to filter on (the default is [], which matches all)
+
+        keys : list, optional
+            List of keys to filter on (the default is [], which matches all)
+
+        values : list, optional
+            List of values to filter on (the default is [], which matches all)
+
+        plain : dict, optional
+            Plaintext meta data to match against record plaintext meta data fields.
+        
+        Returns
+        -------
+        Search
+            Returns reference to self, allows for chaining of match, exclude, range methods.
+        """
+
         m = Params(condition=condition, strategy=strategy, writer_ids=writer, record_ids=record, user_ids=user, content_types=record_type, keys=keys, values=values, plain=plain)
         self.append_match(m)
         return self
 
     def exclude(self, condition="OR", strategy="EXACT", writer=[], record=[], user=[], record_type=[], keys=[], values=[], plain=None):
+        """
+        Public method to construct Query Params on which to Exclude(select) when searching for E3DB records.
+
+        Appends to the List of Exclude Parameters in the Search Object.
+        Independent Exclude Parameters are OR-ed together. 
+
+        Parameters
+        ----------
+        condition : str, optional
+            "OR|AND" (the default is "OR")
+            Provided parameters are either OR-ed or AND-ed together based on the condition provided.
+
+        strategy : str, optional
+            "EXACT|FUZZY|WILDCARD|REGEXP" (the default is "EXACT")
+            Determines the strategy when matching the parameters provided.
+
+        writer : list, optional
+            List of writer ids to filter on (the default is [], which matches all)
+
+        record : list, optional
+            List of reader ids to filter on (the default is [], which matches all)
+
+        user : list, optional
+            List of user ids to filter on (the default is [], which matches all)
+
+        record_type : list, optional
+            List of record_types to filter on (the default is [], which matches all)
+
+        keys : list, optional
+            List of keys to filter on (the default is [], which matches all)
+
+        values : list, optional
+            List of values to filter on (the default is [], which matches all)
+
+        plain : dict, optional
+            Plaintext meta data to match against record plaintext meta data fields.
+        
+        Returns
+        -------
+        Search
+            Returns reference to self, allows for chaining of match, exclude, range methods.
+        """
         e = Params(condition=condition, strategy=strategy, writer_ids=writer, record_ids=record, user_ids=user, content_types=record_type, keys=keys, values=values, plain=plain)
         self.append_exclude(e)
         return self
     
-    def range(self, key="CREATED", format="Unix", zone="UTC", before=None, after=None):
+    def range(self, key="CREATED", format="Unix", zone="UTC", zone_offset=None, before=None, after=None):
+        """
+        Public Method to filter search based on time the E3DB record was created or last modified.
+
+        Parameters
+        ----------
+        key : str, optional
+            "CREATED|MODIFIED" (the default is "CREATED")
+
+        format : str, optional
+            Currently is not a supported parameter (the default is "Unix")
+
+        zone : str, optional
+            Since python time objects are naive or zone-agnostic, this will attempt to append
+            the proper timezone information to the time object for the query.
+            Currently supported are:
+                "PST":"-08:00", "MST":"-07:00", "CST":"-06:00", "EST":"-05:00", "UTC":"+00:00"
+                (the default is "UTC" if the proper timezone cannot be found, which represents +00:00)
+
+        zone_offset : str, optional
+            If provided this offset will be used over zone.
+            Accepts the format "[+|-]dd:dd"
+            (the default is None(UTC), which will attempt to use zone if provided)
+        
+        before : time, optional
+            Search only for records that come before this time 
+            (the default is None, which leaves no upper bound on the query)
+        
+        after : time, optional
+            Search only for record that come after this time 
+            (the default is None, which leaves no lower bound on the query)
+        
+        Returns
+        -------
+        Search
+            Returns reference to self, allows for chaining of match, exclude, range methods.
+        """
+
         r = Range(key=key, format=format, zone=zone, before=before, after=after)
         self.__range = r
         return self

--- a/e3db/types/search.py
+++ b/e3db/types/search.py
@@ -1,0 +1,150 @@
+import time
+from .search_range import Range
+from .search_params import Params
+
+class Search(object):
+    def __init__(self, last_index=0, count=50, include_all_writers=False, include_data=False, match=None, exclude=None, range=None): 
+        """
+        Initialize the search v2 class.
+
+        This object type is used to build a v2/search query to run against the server.
+        It is exposed through the e3db.Client.search method.
+
+        Parameters
+        """
+        self.__next_token = int(last_index)
+        self.__limit = int(count)
+        self.__include_data = bool(include_data)
+        self.__include_all_writers = bool(include_all_writers)
+        self.__match = match if match else [] 
+        self.__exclude = exclude if exclude else []
+        self.__range = None
+        
+    def append_match(self, p):
+        self.__match.append(p)
+
+    def append_exclude(self, p):
+        self.__exclude.append(p)
+
+    # count getters
+    @property
+    def count(self):
+        """
+        Get count of Query.
+
+        Parameters
+        ----------
+        None
+
+        Returns
+        -------
+        int
+            Get count of records.
+        """
+        return self.__limit
+
+    # after_index getters
+    @property
+    def after_index(self):
+        """
+        Get after_index of Query.
+
+        Parameters
+        ----------
+        None
+
+        Returns
+        -------
+        int
+            Get after_index of the Query.
+        """
+        return self.__next_token
+
+    @after_index.setter
+    def after_index(self, value):
+        """
+        Set after_index of QueryResult
+
+        Parameters
+        ----------
+        value: int
+            Set after_index from server result
+
+        Returns
+        -------
+        None
+        """
+        self.__next_token = int(value)
+
+    # include_data getters
+    @property
+    def include_data(self):
+        """
+        Get included_data of Query.
+
+        Parameters
+        ----------
+        None
+
+        Returns
+        -------
+        bool
+            Whether data is included with the records.
+        """
+        return self.__include_data
+
+
+    # include_all_writers getters
+    @property
+    def include_all_writers(self):
+        """
+        Get whether the query included all writers.
+
+        Parameters
+        ----------
+        None
+
+        Returns
+        -------
+        bool
+            include_all_writers
+        """
+        return self.__include_all_writers
+
+    def to_json(self):
+        """
+        Serialize the configuration as JSON-style object.
+
+        Parameters
+        ----------
+        None
+
+        Returns
+        -------
+        dict
+            JSON-style document containing the Query elements.
+        """
+        return {
+            "limit": int(self.__limit),
+            "next_token": int(self.__next_token),
+            "include_all_writers": bool(self.__include_all_writers),
+            "include_data": bool(self.__include_data),
+            "match": [i.to_json() for i in self.__match],
+            "exclude": [i.to_json() for i in self.__exclude],
+            "range": self.__range.to_json() if self.__range is not None else {}
+        }
+
+    def match(self, condition="OR", strategy="EXACT", writer=[], record=[], user=[], record_type=[], keys=[], values=[], plain=None):
+        m = Params(condition=condition, strategy=strategy, writer_ids=writer, record_ids=record, user_ids=user, content_types=record_type, keys=keys, values=values, plain=plain)
+        self.append_match(m)
+        return self
+
+    def exclude(self, condition="OR", strategy="EXACT", writer=[], record=[], user=[], record_type=[], keys=[], values=[], plain=None):
+        e = Params(condition=condition, strategy=strategy, writer_ids=writer, record_ids=record, user_ids=user, content_types=record_type, keys=keys, values=values, plain=plain)
+        self.append_exclude(e)
+        return self
+    
+    def range(self, key="CREATED", format="Unix", zone="UTC", before=None, after=None):
+        r = Range(key=key, format=format, zone=zone, before=before, after=after)
+        self.__range = r
+        return self

--- a/e3db/types/search_params.py
+++ b/e3db/types/search_params.py
@@ -1,19 +1,290 @@
 import uuid
 
-class Params():
+class Params(object):
     def __init__(self, condition="OR", strategy="EXACT", keys=None, values=None, writer_ids=None, user_ids=None, record_ids=None, content_types=None, plain={}):
-        # python3 is picky about uuids, cant pass a uuid to uuid.UUID
+        """
+        Initialize the Search Params class.
+
+        This object type is used to build the params for searching with E3DB.
+
+        Parameters
+        ----------
+        condition : str, optional
+            "OR|AND" (the default is "OR")
+            Provided parameters are either OR-ed or AND-ed together based on the condition provided.
+
+        strategy : str, optional
+            "EXACT|FUZZY|WILDCARD|REGEXP" (the default is "EXACT")
+            Determines the strategy when matching the parameters provided.
+
+        writer : list, optional
+            List of writer ids to filter on (the default is [], which matches all)
+
+        record : list, optional
+            List of reader ids to filter on (the default is [], which matches all)
+
+        user : list, optional
+            List of user ids to filter on (the default is [], which matches all)
+
+        record_type : list, optional
+            List of record_types to filter on (the default is [], which matches all)
+
+        keys : list, optional
+            List of keys to filter on (the default is [], which matches all)
+
+        values : list, optional
+            List of values to filter on (the default is [], which matches all)
+
+        plain : dict, optional
+            Plaintext meta data to match against record plaintext meta data fields.
+        
+        Returns
+        -------
+        Params
+        """
         self.__condition = condition
         self.__strategy = strategy
-        self.__writer_ids = [i if isinstance(i, uuid.UUID) else uuid.UUID(i) for i in user_ids]
+        self.__writer_ids = [i if isinstance(i, uuid.UUID) else uuid.UUID(i) for i in writer_ids]
         self.__user_ids = [i if isinstance(i, uuid.UUID) else uuid.UUID(i) for i in user_ids]
-        self.__record_ids = [i if isinstance(i, uuid.UUID) else uuid.UUID(i) for i in user_ids]
+        self.__record_ids = [i if isinstance(i, uuid.UUID) else uuid.UUID(i) for i in record_ids]
         self.__content_types = [str(i) for i in content_types]
         self.__plain = dict(plain) if plain is not None else None
         self.__values = [str(i) for i in values]
         self.__keys = [str(i) for i in keys]
 
+    @property
+    def condition(self):
+        """
+        Get condition of Search Params
+        
+        Returns
+        -------
+        str
+            "OR|AND"
+        """
+        return self.__condition
+
+    @condition.setter
+    def condition(self, s):
+        """
+        Set condition of Search Params
+
+        Parameters
+        ----------
+        s : str
+            "OR|AND"
+
+        Returns
+        -------
+        None
+        """
+        self.__condition = s
+
+    @property
+    def strategy(self):
+        """
+        Get strategy of Search Params
+        
+        Returns
+        -------
+        str
+            "EXACT|FUZZY|WILDCARD|REGEXP" 
+        """
+        return self.__strategy
+
+    @strategy.setter
+    def strategy(self, s):
+        """
+        Set strategy of Search Params
+
+        Parameters
+        ----------
+        s : str
+            "EXACT|FUZZY|WILDCARD|REGEXP" 
+
+        Returns
+        -------
+        None
+        """
+        self.__strategy = s
+
+    @property
+    def users(self):
+        """
+        Get user_ids of Search Params
+        
+        Returns
+        -------
+        list
+            list of user_ids in this Param object
+        """
+        return self.__user_ids
+
+    @users.setter
+    def users(self, ids):
+        """
+        Set user_ids of Search Params
+
+        Parameters
+        ----------
+        ids : list
+            list of user_ids to set in this Search Param
+
+        Returns
+        -------
+        None
+        """
+        self.__user_ids = ids
+
+    @property
+    def writers(self):
+        """
+        Get writer_ids of Search Params
+        
+        Returns
+        -------
+        list
+            list of writer_ids in this Param object
+        """
+        return self.__writer_ids
+
+    @writers.setter
+    def writers(self, ids):
+        """
+        Set writer_ids of Search Params
+
+        Parameters
+        ----------
+        ids : list
+            list of writer_ids to set in this Search Param
+
+        Returns
+        -------
+        None
+        """
+        self.__writer_ids = ids
+
+    @property
+    def records(self):
+        """
+        Get record_ids of Search Params
+        
+        Returns
+        -------
+        list
+            list of record_ids in this Param object
+        """
+        return self.__record_ids
+
+    @records.setter
+    def records(self, ids):
+        """
+        Set record_ids of Search Params
+
+        Parameters
+        ----------
+        ids : list
+            list of record_ids to set in this Search Param
+
+        Returns
+        -------
+        None
+        """
+        self.__record_ids = ids
+
+    @property
+    def keys(self):
+        """
+        Get keys of Search Params
+        
+        Returns
+        -------
+        list
+            list of keys in this Param object
+        """
+        return self.__keys
+
+    @keys.setter
+    def keys(self, s):
+        """
+        Set keys of Search Params
+
+        Parameters
+        ----------
+        s : list
+            list of keys to set in this Search Param
+
+        Returns
+        -------
+        None
+        """
+        self.__keys = s
+
+    @property
+    def values(self):
+        """
+        Get values of Search Params
+        
+        Returns
+        -------
+        list
+            list of values in this Param object
+        """
+        return self.__values
+
+    @values.setter
+    def values(self, s):
+        """
+        Set values of Search Params
+
+        Parameters
+        ----------
+        s : list
+            list of values to set in this Search Param
+
+        Returns
+        -------
+        None
+        """
+        self.__values = s
+
+    @property
+    def plain(self):
+        """
+        Get plain of Search Params
+        
+        Returns
+        -------
+        dict
+            dict of plain meta tags in this Param object
+        """
+        return self.__plain
+
+    @plain.setter
+    def plain(self, d):
+        """
+        Set plain of Search Params
+
+        Parameters
+        ----------
+        d: dict
+            dict of plain meta tags in this Param object
+
+        Returns
+        -------
+        None
+        """
+        self.__plain = d
+
     def to_json(self):
+        """
+        Serialize the configuration as JSON-style object.
+        
+        Returns
+        -------
+        dict
+            JSON-style document containing the Param elements.
+        """
         return {
             "condition": self.__condition,
             "strategy": self.__strategy,

--- a/e3db/types/search_params.py
+++ b/e3db/types/search_params.py
@@ -1,0 +1,29 @@
+import uuid
+
+class Params():
+    def __init__(self, condition="OR", strategy="EXACT", keys=None, values=None, writer_ids=None, user_ids=None, record_ids=None, content_types=None, plain={}):
+        # python3 is picky about uuids, cant pass a uuid to uuid.UUID
+        self.__condition = condition
+        self.__strategy = strategy
+        self.__writer_ids = [i if isinstance(i, uuid.UUID) else uuid.UUID(i) for i in user_ids]
+        self.__user_ids = [i if isinstance(i, uuid.UUID) else uuid.UUID(i) for i in user_ids]
+        self.__record_ids = [i if isinstance(i, uuid.UUID) else uuid.UUID(i) for i in user_ids]
+        self.__content_types = [str(i) for i in content_types]
+        self.__plain = dict(plain) if plain is not None else None
+        self.__values = [str(i) for i in values]
+        self.__keys = [str(i) for i in keys]
+
+    def to_json(self):
+        return {
+            "condition": self.__condition,
+            "strategy": self.__strategy,
+            "terms": {
+                "writer_ids": [str(i) for i in self.__writer_ids],
+                "user_ids": [str(i) for i in self.__user_ids],
+                "record_ids": [str(i) for i in self.__record_ids],
+                "content_types": [str(i) for i in self.__content_types],
+                "keys": [str(i) for i in self.__keys],
+                "values": [str(i) for i in self.__values],
+                "tags": self.__plain
+            }
+        }

--- a/e3db/types/search_range.py
+++ b/e3db/types/search_range.py
@@ -1,38 +1,214 @@
 
 class Range():
     def __init__(self, key="CREATED", format="Unix", zone="UTC", zone_offset=None, before=None, after=None):
-        '''
-        before, after are naive datetime objects
+        """
+        Initialize the Range class for use in Search. This class can be manually created if needed, but 
+        the Search.range() method handles the Search workflow.
 
-        '''
-        self.__key= key
+        Parameters
+        ----------
+        key : str, optional
+            "CREATED|MODIFIED" (the default is "CREATED")
+
+        format : str, optional
+            Currently is not a supported parameter (the default is "Unix")
+
+        zone : str, optional
+            Since python time objects are naive or zone-agnostic, this will attempt to append
+            the proper timezone information to the time object for the query.
+            Currently supported are:
+                "PST":"-08:00", "MST":"-07:00", "CST":"-06:00", "EST":"-05:00", "UTC":"+00:00"
+                (the default is "UTC" if the proper timezone cannot be found, which represents +00:00)
+
+        zone_offset : str, optional
+            If provided this offset will be used over zone.
+            Accepts the format "[+|-]dd:dd"
+            (the default is None(UTC), which will attempt to use zone if provided)
+        
+        before : time, optional
+            Search only for records that come before this time 
+            (the default is None, which leaves no upper bound on the query)
+        
+        after : time, optional
+            Search only for record that come after this time 
+            (the default is None, which leaves no lower bound on the query)
+        
+        Returns
+        ----------
+        None
+        """
+        self.__key = key
         self.__format = format
         self.__zone = zone
         self.__before = before 
         self.__after = after
+        self.zone_dict = {
+            "PST":"-08:00",
+            "MST":"-07:00",
+            "CST":"-06:00",
+            "EST":"-05:00",
+            "UTC":"+00:00"
+        } 
         if zone_offset is not None:
             self.__zone_offset = zone_offset
         else:
-            zone_dict = {
-                "PST":"-08:00",
-                "MST":"-07:00",
-                "CST":"-06:00",
-                "EST":"-05:00",
-                "UTC":"+00:00"
-            } 
-            self.__zone_offset = zone_dict.get(zone, "+00:00")
+            self.__zone_offset = self.zone_dict.get(zone, "+00:00")
     
     @property
     def before(self):
+        """
+        Get the before time with time zone information appended as a string
+
+        Returns
+        -------
+        str
+            Before time properly formatted to send to E3DB.
+        """
         return self.__before.isoformat("T") + self.__zone_offset
+    
+    @before.setter
+    def before(self, t):
+        """
+        Set the before time of Search Range
+
+        Parameters
+        ----------
+        t : time
+            time to search before
+
+        Returns
+        -------
+        None
+        """
+        self.__before = t
 
     @property
     def after(self):
+        """
+        Get the after time with time zone information appended as a string
+
+        Returns
+        -------
+        str
+            Before time properly formatted to send to E3DB.
+        """
         return self.__after.isoformat("T") + self.__zone_offset
 
+    @after.setter
+    def after(self, t):
+        """
+        Set the after time of Search Range
+
+        Parameters
+        ----------
+        t : time
+            time to search after
+
+        Returns
+        -------
+        None
+        """
+        self.__after = t
+
+    @property
+    def zone(self):
+        """
+        Get zone of Search Range
+        
+        Returns
+        -------
+        str
+            zone value
+        """
+        return self.__zone
+
+    @zone.setter
+    def zone(self, z):
+        """
+        Set zone for Search Range. Will default to "UTC" if proper timezone cannot be found, 
+        and will override the value set in zone_offset.
+
+        Parameters
+        ----------
+        z : str
+            Proper zone parameter:
+            "PST":"-08:00", "MST":"-07:00", "CST":"-06:00", "EST":"-05:00", "UTC":"+00:00"
+
+        Returns
+        -------
+        None
+        """
+        self.zone = z
+        self.__zone_offset = self.zone_dict.get(z, "+00:00")
+
+    @property
+    def zone_offset(self):
+        """
+        Get zone_offset of Search Range
+        
+        Returns
+        -------
+        str
+            zone_offset value
+        """
+        return self.__zone_offset
+
+    @zone_offset.setter
+    def zone_offset(self, z):
+        """
+        Set zone_offset for Search Range
+
+        Parameters
+        ----------
+        z : str
+            Proper zone_offset parameter:
+            Accepts the format "[+|-]dd:dd"
+
+        Returns
+        -------
+        None
+        """
+        self.zone_offset = z
+    
+    @property
+    def key(self):
+        """
+        Get Key for Search Range
+        
+        Returns
+        -------
+        str
+            "CREATED|MODIFIED"
+        """
+        return self.__key
+
+    @key.setter
+    def key(self, k):
+        """
+        Set Key for Search Range
+
+        Parameters
+        ----------
+        k : str
+            Valid keys: "CREATED|MODIFIED"
+
+        Returns
+        -------
+        None
+        """
+        self.__key = k
+
     def to_json(self):
+        """
+        Serialize the configuration as JSON-style object.
+        
+        Returns
+        -------
+        dict
+            JSON-style document containing the Range elements.
+        """
         return {
             "range_key": str(self.__key),
-            "before": self.__before.isoformat("T") + self.__zone_offset,
-            "after": self.__after.isoformat("T") + self.__zone_offset
+            "before": self.before,
+            "after": self.after
         }

--- a/e3db/types/search_range.py
+++ b/e3db/types/search_range.py
@@ -1,0 +1,38 @@
+
+class Range():
+    def __init__(self, key="CREATED", format="Unix", zone="UTC", zone_offset=None, before=None, after=None):
+        '''
+        before, after are naive datetime objects
+
+        '''
+        self.__key= key
+        self.__format = format
+        self.__zone = zone
+        self.__before = before 
+        self.__after = after
+        if zone_offset is not None:
+            self.__zone_offset = zone_offset
+        else:
+            zone_dict = {
+                "PST":"-08:00",
+                "MST":"-07:00",
+                "CST":"-06:00",
+                "EST":"-05:00",
+                "UTC":"+00:00"
+            } 
+            self.__zone_offset = zone_dict.get(zone, "+00:00")
+    
+    @property
+    def before(self):
+        return self.__before.isoformat("T") + self.__zone_offset
+
+    @property
+    def after(self):
+        return self.__after.isoformat("T") + self.__zone_offset
+
+    def to_json(self):
+        return {
+            "range_key": str(self.__key),
+            "before": self.__before.isoformat("T") + self.__zone_offset,
+            "after": self.__after.isoformat("T") + self.__zone_offset
+        }

--- a/e3db/types/search_result.py
+++ b/e3db/types/search_result.py
@@ -20,9 +20,16 @@ class SearchResult(object):
         records : list<e3db.Record>
             A list of records to store for later iteration and operations.
 
+        after_index : int
+            Index that indicates where to start the next query for batch jobs.
+
+        search_id : str
+            ID to access search_id for async searches, but currently is not implemented in
+            the search service.  
+
         Returns
         -------
-        None
+        SearchResult
         """
         if search and (not isinstance(search, Search)):
             raise TypeError("Search object is not e3db.Search type. Given type: {0}".format(type(search)))
@@ -39,13 +46,17 @@ class SearchResult(object):
 
     @property
     def search_id(self):
+        """
+        Get search_id for SearchResult
+        
+        Returns
+        -------
+        str
+            ID to access search_id for async searches, but currently is not implemented in
+            the search service.  
+        """
         return self.__search_id
     
-    @search_id.setter
-    def search_id(self, id):
-        self.__search_id = id
-
-    # after_index getters and setters
     @property
     def after_index(self):
         """
@@ -62,21 +73,17 @@ class SearchResult(object):
         """
         return self.__after_index
 
-    @after_index.setter
-    def after_index(self, value):
+    @property
+    def records(self):
         """
-        Set after_index of SearchResult
-
-        Parameters
-        ----------
-        value: int
-            Set after_index from server result
-
+        Get records for SearchResult
+        
         Returns
         -------
-        None
+        Record
+            Returns Records for manual access
         """
-        self.__after_index = int(value)
+        return self.__records
 
     def __iter__(self):
         """

--- a/e3db/types/search_result.py
+++ b/e3db/types/search_result.py
@@ -1,0 +1,111 @@
+from .search import Search
+from .record import Record
+
+class SearchResult(object):
+
+    def __init__(self, search, records, after_index=0, search_id=""):
+        """
+        Initialize the SearchResult class.
+
+        This object type is used as a storage for the results of v2 Search query.
+        The main purpose is to allow iteration over a list of returned records
+        that are the result of a Search operation.
+
+        Parameters
+        ----------
+        search : e3db.Search
+            Search object stored for later operations, such as looking up the
+            after index returned from the server during search execution.
+
+        records : list<e3db.Record>
+            A list of records to store for later iteration and operations.
+
+        Returns
+        -------
+        None
+        """
+        if search and (not isinstance(search, Search)):
+            raise TypeError("Search object is not e3db.Search type. Given type: {0}".format(type(search)))
+        else:
+            self.__search = search
+
+        # Check that all records in this list are of type e3db.Record
+        if records and (not all(isinstance(x, Record) for x in records)):
+            raise TypeError("Records should be a list of e3db.Record types. Given type: {0}".format(type(records)))
+        else:
+            self.__records = records
+        self.__after_index = after_index
+        self.__search_id = search_id
+
+    @property
+    def search_id(self):
+        return self.__search_id
+    
+    @search_id.setter
+    def search_id(self, id):
+        self.__search_id = id
+
+    # after_index getters and setters
+    @property
+    def after_index(self):
+        """
+        Get after_index of Search.
+
+        Parameters
+        ----------
+        None
+
+        Returns
+        -------
+        int
+            Get after_index of the Search.
+        """
+        return self.__after_index
+
+    @after_index.setter
+    def after_index(self, value):
+        """
+        Set after_index of SearchResult
+
+        Parameters
+        ----------
+        value: int
+            Set after_index from server result
+
+        Returns
+        -------
+        None
+        """
+        self.__after_index = int(value)
+
+    def __iter__(self):
+        """
+        Iterate over record objects.
+
+        Parameters
+        ----------
+        None
+
+        Returns
+        -------
+        iter
+            Iterator over record objects returned from the Search.
+        """
+
+        return iter(self.__records)
+
+    def __len__(self):
+        """
+        Get amount of records returned from the Search.
+
+        Parameters
+        ----------
+        None
+
+        Returns
+        -------
+        int
+            Amount of records returned from the Search.
+        """
+
+        return len(self.__records)

--- a/e3db/types/search_result.py
+++ b/e3db/types/search_result.py
@@ -3,7 +3,7 @@ from .record import Record
 
 class SearchResult(object):
 
-    def __init__(self, search, records, after_index=0, search_id=""):
+    def __init__(self, search, records, after_index=0, total_results=0, search_id=""):
         """
         Initialize the SearchResult class.
 
@@ -25,7 +25,7 @@ class SearchResult(object):
 
         search_id : str
             ID to access search_id for async searches, but currently is not implemented in
-            the search service.  
+            E3DB.  
 
         Returns
         -------
@@ -43,6 +43,7 @@ class SearchResult(object):
             self.__records = records
         self.__after_index = after_index
         self.__search_id = search_id
+        self.__total_results = total_results
 
     @property
     def search_id(self):
@@ -53,7 +54,7 @@ class SearchResult(object):
         -------
         str
             ID to access search_id for async searches, but currently is not implemented in
-            the search service.  
+            the E3DB.  
         """
         return self.__search_id
     
@@ -80,10 +81,23 @@ class SearchResult(object):
         
         Returns
         -------
-        Record
+        List[Record]
             Returns Records for manual access
         """
         return self.__records
+
+    @property
+    def total_results(self):
+        """
+        Get total results of a search, may be more than contained in SearchResult records.
+        To get the full amount of results, call search again with the after index of this SearchResult
+    
+        Returns
+        -------
+        int
+            Number of results found in E3DB
+        """
+        return self.__total_results
 
     def __iter__(self):
         """

--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,5 @@
 from setuptools import setup, find_packages
-version = "2.0.2"
+version = "2.1.0"
 setup(
   name="e3db",
   version=version,


### PR DESCRIPTION
Initial PR to support v2 queries with the python SDK. I mirrored much of the structure of the current SDK, but the previous query workflow doesn't make as much sense with the more complex v2 queries: 
 old:
```
record = client.query(record=[record_type])
```
new version allows chaining of match, exclude, range:
```
query = QueryAdv().match(record=[record_type]) # construct query
query = query.exclude(...).range(...) # add more parameters
record = client.execute(query) # execute query
```
I've spent so long in goland, so please let me know if there are more pythonic ways structuring the query language. Also, for now at least, v2 queries comes in as an add-on (QueryAdv) to avoid a breaking change, but I assume we'll eventually deprecate v1 query in favor of v2 query and the classes can move around.

docs & examples for a later sprint