### PR TITLE
Refactor of after-before to start-end or other

### DIFF
--- a/e3db/tests/test_search_integration.py
+++ b/e3db/tests/test_search_integration.py
@@ -182,12 +182,12 @@ class TestSearchIntegration():
         assert(len(results)==1)
 
     def test_v2_invalid_range(self):
-        q = e3db.types.Search(include_data=True).match(record_types=[self.record_type]).range(before=datetime.now(), after=datetime.now())
+        q = e3db.types.Search(include_data=True).match(record_types=[self.record_type]).range(start=datetime.now(), end=datetime.now())
         results = self.client1.search(q)
         assert(len(results)==0)
 
     def test_v2_valid_range(self):
-        q = e3db.types.Search(include_data=True).match(record_types=[self.record_type]).range(zone="PST", before=datetime.now()+timedelta(hours=1), after=datetime.now()+timedelta(hours=-1))
+        q = e3db.types.Search(include_data=True).match(record_types=[self.record_type]).range(zone="PST", start=datetime.now()+timedelta(hours=-1), end=datetime.now()+timedelta(hours=1))
         results = self.client1.search(q)
         assert(len(results)==2)
 

--- a/e3db/types/search.py
+++ b/e3db/types/search.py
@@ -345,7 +345,7 @@ class Search(object):
         self.append_exclude(e)
         return self
     
-    def range(self, key="CREATED", format="Unix", zone="UTC", zone_offset=None, before=None, after=None):
+    def range(self, key="CREATED", format="Unix", zone="UTC", zone_offset=None, start=None, end=None):
         """
         Public Method to filter search based on time the E3DB record was created or last modified.
 
@@ -369,13 +369,13 @@ class Search(object):
             Accepts the format "[+|-]dd:dd"
             (the default is None(UTC), which will attempt to use zone if provided)
         
-        before : time, optional
+        start : time, optional
+            Search only for records that come after this time 
+            (the default is None, which leaves no lower bound on the query)
+        
+        end : time, optional
             Search only for records that come before this time 
             (the default is None, which leaves no upper bound on the query)
-        
-        after : time, optional
-            Search only for record that come after this time 
-            (the default is None, which leaves no lower bound on the query)
         
         Returns
         -------
@@ -383,6 +383,6 @@ class Search(object):
             Returns reference to self, allows for chaining of match, exclude, range methods.
         """
 
-        r = Range(key=key, format=format, zone=zone, before=before, after=after)
+        r = Range(key=key, format=format, zone=zone, start=start, end=end)
         self.__range = r
         return self

--- a/e3db/types/search_range.py
+++ b/e3db/types/search_range.py
@@ -1,6 +1,6 @@
 
 class Range():
-    def __init__(self, key="CREATED", format="Unix", zone="UTC", zone_offset=None, before=None, after=None):
+    def __init__(self, key="CREATED", format="Unix", zone="UTC", zone_offset=None, start=None, end=None):
         """
         Initialize the Range class for use in Search. This class can be manually created if needed, but 
         the Search.range() method handles the Search workflow.
@@ -25,7 +25,7 @@ class Range():
             Accepts the format "[+|-]dd:dd"
             (the default is None(UTC), which will attempt to use zone if provided)
         
-        before : time, optional
+        end : time, optional
             Search only for records that come before this time 
             (the default is None, which leaves no upper bound on the query)
         
@@ -40,8 +40,8 @@ class Range():
         self.__key = key
         self.__format = format
         self.__zone = zone
-        self.__before = before 
-        self.__after = after
+        self.__start = start 
+        self.__end = end
         self.zone_dict = {
             "PST":"-08:00",
             "MST":"-07:00",
@@ -55,54 +55,54 @@ class Range():
             self.__zone_offset = self.zone_dict.get(zone, "+00:00")
     
     @property
-    def before(self):
+    def end(self):
         """
-        Get the before time with time zone information appended as a string
+        Get the end time with time zone information appended as a string
 
         Returns
         -------
         str
-            Before time properly formatted to send to E3DB.
+            end time properly formatted to send to E3DB.
         """
-        return self.__before.isoformat("T") + self.__zone_offset
+        return self.__end.isoformat("T") + self.__zone_offset
     
-    @before.setter
-    def before(self, t):
+    @end.setter
+    def end(self, t):
         """
-        Set the before time of Search Range
+        Set the end time of Search Range
 
         Parameters
         ----------
-        t : time
-            time to search before
+        t : datetime
+            upper time bound for Search Range
 
         Returns
         -------
         None
         """
-        self.__before = t
+        self.__end = t
 
     @property
-    def after(self):
+    def start(self):
         """
-        Get the after time with time zone information appended as a string
+        Get the start time with time zone information appended as a string
 
         Returns
         -------
         str
-            Before time properly formatted to send to E3DB.
+            start time properly formatted to send to E3DB.
         """
-        return self.__after.isoformat("T") + self.__zone_offset
+        return self.__start.isoformat("T") + self.__zone_offset
 
-    @after.setter
-    def after(self, t):
+    @start.setter
+    def start(self, t):
         """
-        Set the after time of Search Range
+        Set the start time of Search Range
 
         Parameters
         ----------
-        t : time
-            time to search after
+        t : datetime
+            lower time bound for Search Range
 
         Returns
         -------
@@ -209,6 +209,6 @@ class Range():
         """
         return {
             "range_key": str(self.__key),
-            "before": self.before,
-            "after": self.after
+            "before": self.__end,
+            "after": self.__start,
         }


### PR DESCRIPTION
From a conversation with @efabens, time range naming conventions of `before` and `after` carry over from the search service can be confusing for users. Where `after` is the `start` time and `before` is the `end` time. 

Thoughts on moving to `start` and `end`? Other options are `from`-`to` or `start_time`-`end_time`