### PR TITLE
whitespace error

### DIFF
--- a/e3db/client.py
+++ b/e3db/client.py
@@ -1002,7 +1002,7 @@ class Client:
         ak = self.__get_access_key(self.client_id, self.client_id, self.client_id, record_type)
         if ak is None:
             ak = Crypto.random_key()
-        self.__put_access_key(self.client_id, self.client_id, self.client_id, record_type, ak) # Give yourself the ak 
+            self.__put_access_key(self.client_id, self.client_id, self.client_id, record_type, ak) # Give yourself the ak 
         self.__put_access_key(self.client_id, self.client_id, reader_id, record_type, ak)
 
         allow_read = {

--- a/e3db/tests/test_share_integration.py
+++ b/e3db/tests/test_share_integration.py
@@ -102,3 +102,8 @@ class TestShareIntegration():
 
         self.client1.read(record.meta.record_id)
     
+    def test_share_twice(self):
+        record_type = "sharing3"
+        self.client1.share(record_type, self.client2.client_id)
+        self.client1.revoke(record_type, self.client2.client_id)
+        self.client1.share(record_type, self.client2.client_id)

--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,5 @@
 from setuptools import setup, find_packages
-version = "2.1.1"
+version = "2.1.2"
 setup(
   name="e3db",
   version=version,


### PR DESCRIPTION
Introduced a whitespace error in previous PR, we should only share access key with self if it's not retrieved from server to prevent 409.