### PR TITLE
Fix/range param bug

### DIFF
--- a/e3db/tests/test_search_integration.py
+++ b/e3db/tests/test_search_integration.py
@@ -187,19 +187,29 @@ class TestSearchIntegration():
         assert(len(results)==0)
 
     def test_v2_range_end_none(self):
-        q = e3db.types.Search(include_data=True).match(record_types=[self.record_type]).range(zone="PST", start=datetime.now())
+        q = e3db.types.Search(include_data=True).match(record_types=[self.record_type]).range(zone="PDT", start=datetime.now())
         results = self.client1.search(q)
         assert(len(results)==0)
 
     def test_v2_range_start_none(self):
-        q = e3db.types.Search(include_data=True).match(record_types=[self.record_type]).range(zone="PST", end=datetime.now())
+        q = e3db.types.Search(include_data=True).match(record_types=[self.record_type]).range(zone="PDT", end=datetime.now())
         results = self.client1.search(q)
         assert(len(results)==2)
 
     def test_v2_valid_range(self):
-        q = e3db.types.Search(include_data=True).match(record_types=[self.record_type]).range(zone="PST", start=datetime.now()+timedelta(hours=-1), end=datetime.now()+timedelta(hours=1))
+        q = e3db.types.Search(include_data=True).match(record_types=[self.record_type]).range(zone="PDT", start=datetime.now()+timedelta(hours=-1), end=datetime.now()+timedelta(hours=1))
         results = self.client1.search(q)
         assert(len(results)==2)
+
+    def test_v2_valid_range_offset(self):
+        q = e3db.types.Search(include_data=True).match(record_types=[self.record_type]).range(zone_offset="-07:00", start=datetime.now()+timedelta(hours=-1), end=datetime.now()+timedelta(hours=1))
+        results = self.client1.search(q)
+        assert(len(results)==2)
+
+    def test_v2_invalid_range_offset(self):
+        q = e3db.types.Search(include_data=True).match(record_types=[self.record_type]).range(zone_offset=None, start=datetime.now()+timedelta(hours=-1), end=datetime.now()+timedelta(hours=1))
+        results = self.client1.search(q)
+        assert(len(results)==0)
 
     def test_v2_multi_match(self):
         record1_id = self.record1.meta.record_id

--- a/e3db/types/search.py
+++ b/e3db/types/search.py
@@ -383,6 +383,6 @@ class Search(object):
             Returns reference to self, allows for chaining of match, exclude, range methods.
         """
 
-        r = Range(key=key, format=format, zone=zone, start=start, end=end)
+        r = Range(key=key, format=format, zone=zone, zone_offset=zone_offset, start=start, end=end)
         self.__range = r
         return self

--- a/e3db/types/search.py
+++ b/e3db/types/search.py
@@ -84,6 +84,29 @@ class Search(object):
         self.__match = p
 
     @property
+    def range_filter(self):
+        """
+        Get range parameters.
+        
+        Returns
+        -------
+        Range
+            Range object with range information
+        """
+        return self.__range
+
+    @range_filter.setter
+    def range_filter(self, r):
+        """
+        Set range parameters.
+
+        Returns
+        -------
+        None
+        """
+        self.__range = r
+
+    @property
     def excludes(self):
         """
         Get list of Params on which to exclude.

--- a/e3db/types/search_range.py
+++ b/e3db/types/search_range.py
@@ -61,6 +61,17 @@ class Range():
     @property
     def end(self):
         """
+        Get the end time as datetime object
+
+        Returns
+        -------
+        datetime
+            end time for query.
+        """
+        return self.__end
+    
+    def end_formatted(self):
+        """
         Get the end time with time zone information appended as a string
 
         Returns
@@ -71,7 +82,7 @@ class Range():
         if self.__end is None:
             return None
         return self.__end.isoformat("T") + self.__zone_offset
-    
+
     @end.setter
     def end(self, t):
         """
@@ -90,6 +101,17 @@ class Range():
 
     @property
     def start(self):
+        """
+        Get the start time as datetime object
+
+        Returns
+        -------
+        datetime
+            start time for query.
+        """
+        return self.__start
+
+    def start_formatted(self):
         """
         Get the start time with time zone information appended as a string
 
@@ -116,7 +138,7 @@ class Range():
         -------
         None
         """
-        self.__after = t
+        self.__start = t
 
     @property
     def zone(self):
@@ -217,8 +239,8 @@ class Range():
         """
         to_serialize = {
             "range_key": str(self.__key),
-            "before": self.end,
-            "after": self.start,
+            "before": self.end_formatted(),
+            "after": self.start_formatted(),
         }
         # remove None (JSON null) objects
         for key, value in list(to_serialize.items()):

--- a/e3db/types/search_range.py
+++ b/e3db/types/search_range.py
@@ -44,9 +44,13 @@ class Range():
         self.__end = end
         self.zone_dict = {
             "PST":"-08:00",
+            "PDT":"-07:00",
             "MST":"-07:00",
+            "MDT":"-06:00",
             "CST":"-06:00",
+            "CDT":"-05:00",
             "EST":"-05:00",
+            "EDT":"-04:00",
             "UTC":"+00:00"
         } 
         if zone_offset is not None:


### PR DESCRIPTION
Bug fix where I'm not passing down the time_zone offset param on construction here in the first commit: r = Range(key=key, format=format, zone=zone,` zone_offset=zone_offset`, start=start, end=end)

Additional misc time fixes due to daylight savings.
Quality of life changes to expose manual getters and setters for range, start time, and end time, bc we have pseudo private properties.