### PR TITLE
Fix/range param bug 

### DIFF
--- a/e3db/tests/test_search_integration.py
+++ b/e3db/tests/test_search_integration.py
@@ -187,19 +187,29 @@ class TestSearchIntegration():
         assert(len(results)==0)
 
     def test_v2_range_end_none(self):
-        q = e3db.types.Search(include_data=True).match(record_types=[self.record_type]).range(zone="PST", start=datetime.now())
+        q = e3db.types.Search(include_data=True).match(record_types=[self.record_type]).range(zone="PDT", start=datetime.now())
         results = self.client1.search(q)
         assert(len(results)==0)
 
     def test_v2_range_start_none(self):
-        q = e3db.types.Search(include_data=True).match(record_types=[self.record_type]).range(zone="PST", end=datetime.now())
+        q = e3db.types.Search(include_data=True).match(record_types=[self.record_type]).range(zone="PDT", end=datetime.now())
         results = self.client1.search(q)
         assert(len(results)==2)
 
     def test_v2_valid_range(self):
-        q = e3db.types.Search(include_data=True).match(record_types=[self.record_type]).range(zone="PST", start=datetime.now()+timedelta(hours=-1), end=datetime.now()+timedelta(hours=1))
+        q = e3db.types.Search(include_data=True).match(record_types=[self.record_type]).range(zone="PDT", start=datetime.now()+timedelta(hours=-1), end=datetime.now()+timedelta(hours=1))
         results = self.client1.search(q)
         assert(len(results)==2)
+
+    def test_v2_valid_range_offset(self):
+        q = e3db.types.Search(include_data=True).match(record_types=[self.record_type]).range(zone_offset="-07:00", start=datetime.now()+timedelta(hours=-1), end=datetime.now()+timedelta(hours=1))
+        results = self.client1.search(q)
+        assert(len(results)==2)
+
+    def test_v2_invalid_range_offset(self):
+        q = e3db.types.Search(include_data=True).match(record_types=[self.record_type]).range(zone_offset=None, start=datetime.now()+timedelta(hours=-1), end=datetime.now()+timedelta(hours=1))
+        results = self.client1.search(q)
+        assert(len(results)==0)
 
     def test_v2_multi_match(self):
         record1_id = self.record1.meta.record_id

--- a/e3db/types/search.py
+++ b/e3db/types/search.py
@@ -383,6 +383,6 @@ class Search(object):
             Returns reference to self, allows for chaining of match, exclude, range methods.
         """
 
-        r = Range(key=key, format=format, zone=zone, start=start, end=end)
+        r = Range(key=key, format=format, zone=zone, zone_offset=zone_offset, start=start, end=end)
         self.__range = r
         return self

--- a/e3db/types/search.py
+++ b/e3db/types/search.py
@@ -368,7 +368,7 @@ class Search(object):
         self.append_exclude(e)
         return self
     
-    def range(self, key="CREATED", format="Unix", zone="UTC", zone_offset=None, start=None, end=None):
+    def range(self, key="CREATED", start=None, end=None, zone_offset=None):
         """
         Public Method to filter search based on time the E3DB record was created or last modified.
 
@@ -377,21 +377,6 @@ class Search(object):
         key : str, optional
             "CREATED|MODIFIED" (the default is "CREATED")
 
-        format : str, optional
-            Currently is not a supported parameter (the default is "Unix")
-
-        zone : str, optional
-            Since python time objects are naive or zone-agnostic, this will attempt to append
-            the proper timezone information to the time object for the query.
-            Currently supported are:
-                "PST":"-08:00", "MST":"-07:00", "CST":"-06:00", "EST":"-05:00", "UTC":"+00:00"
-                (the default is "UTC" if the proper timezone cannot be found, which represents +00:00)
-
-        zone_offset : str, optional
-            If provided this offset will be used over zone.
-            Accepts the format "[+|-]dd:dd"
-            (the default is None(UTC), which will attempt to use zone if provided)
-        
         start : time, optional
             Search only for records that come after this time 
             (the default is None, which leaves no lower bound on the query)
@@ -400,12 +385,27 @@ class Search(object):
             Search only for records that come before this time 
             (the default is None, which leaves no upper bound on the query)
         
+        zone_offset : int, optional
+            Accepts int for provided timezone in hour difference from UTC.
+            For PST(UTC-8) provide zone_offset = -8
+            For PDT(UTC-7) provide zone_offset = -7
+
+            If datetime object has timezone information, that will be given precedence.
+            If zone_offset is provided, datetime objects, start and end append this timezone
+                ex:
+                    - input: zone_offset = -7, datetime.isoformat("T") = 2019-01-01T00:00:00Z
+                    - output: 2019-01-01T00:00:00Z-07:00
+                This option should only be used if you know you want to search 
+                for a specific time within a different timezone.
+            If zone_offset == None and tzinfo does not exist, your local timezone will be used.
+            Assumes that start and end have the same timezone information
+
         Returns
         -------
         Search
             Returns reference to self, allows for chaining of match, exclude, range methods.
         """
 
-        r = Range(key=key, format=format, zone=zone, zone_offset=zone_offset, start=start, end=end)
+        r = Range(key=key, start=start, end=end, zone_offset=zone_offset)
         self.__range = r
         return self

--- a/e3db/types/search.py
+++ b/e3db/types/search.py
@@ -377,15 +377,21 @@ class Search(object):
         key : str, optional
             "CREATED|MODIFIED" (the default is "CREATED")
 
-        start : time, optional
-            Search only for records that come after this time 
+        start: datetime, int, optional
+            Search only for record that come after this time 
+            Accepts datetime object with and without timezone information, see zone_offset for more details.
+            OR
+            Accepts int denoting unix epoch time and this will always be in UTC timezone.
             (the default is None, which leaves no lower bound on the query)
         
-        end : time, optional
+        end : datetime, int, optional
             Search only for records that come before this time 
+            Accepts datetime object with and without timezone information, see zone_offset for more details.
+            OR
+            Accepts int denoting unix epoch time and this will always be in UTC timezone.
             (the default is None, which leaves no upper bound on the query)
-        
-        zone_offset : int, optional
+
+        zone_offset : int, str, optional
             Accepts int for provided timezone in hour difference from UTC.
             For PST(UTC-8) provide zone_offset = -8
             For PDT(UTC-7) provide zone_offset = -7

--- a/e3db/types/search.py
+++ b/e3db/types/search.py
@@ -84,6 +84,29 @@ class Search(object):
         self.__match = p
 
     @property
+    def range_filter(self):
+        """
+        Get range parameters.
+        
+        Returns
+        -------
+        Range
+            Range object with range information
+        """
+        return self.__range
+
+    @range_filter.setter
+    def range_filter(self, r):
+        """
+        Set range parameters.
+
+        Returns
+        -------
+        None
+        """
+        self.__range = r
+
+    @property
     def excludes(self):
         """
         Get list of Params on which to exclude.

--- a/e3db/types/search_range.py
+++ b/e3db/types/search_range.py
@@ -61,6 +61,17 @@ class Range():
     @property
     def end(self):
         """
+        Get the end time as datetime object
+
+        Returns
+        -------
+        datetime
+            end time for query.
+        """
+        return self.__end
+    
+    def end_formatted(self):
+        """
         Get the end time with time zone information appended as a string
 
         Returns
@@ -71,7 +82,7 @@ class Range():
         if self.__end is None:
             return None
         return self.__end.isoformat("T") + self.__zone_offset
-    
+
     @end.setter
     def end(self, t):
         """
@@ -90,6 +101,17 @@ class Range():
 
     @property
     def start(self):
+        """
+        Get the start time as datetime object
+
+        Returns
+        -------
+        datetime
+            start time for query.
+        """
+        return self.__start
+
+    def start_formatted(self):
         """
         Get the start time with time zone information appended as a string
 
@@ -116,7 +138,7 @@ class Range():
         -------
         None
         """
-        self.__after = t
+        self.__start = t
 
     @property
     def zone(self):
@@ -217,8 +239,8 @@ class Range():
         """
         to_serialize = {
             "range_key": str(self.__key),
-            "before": self.end,
-            "after": self.start,
+            "before": self.end_formatted(),
+            "after": self.start_formatted(),
         }
         # remove None (JSON null) objects
         for key, value in list(to_serialize.items()):

--- a/e3db/types/search_range.py
+++ b/e3db/types/search_range.py
@@ -44,9 +44,13 @@ class Range():
         self.__end = end
         self.zone_dict = {
             "PST":"-08:00",
+            "PDT":"-07:00",
             "MST":"-07:00",
+            "MDT":"-06:00",
             "CST":"-06:00",
+            "CDT":"-05:00",
             "EST":"-05:00",
+            "EDT":"-04:00",
             "UTC":"+00:00"
         } 
         if zone_offset is not None:


### PR DESCRIPTION
previous PR https://github.com/tozny/e3db-python/pull/32.
Timezones are hard, thus I petition to eliminate timezones and only work off of 1552602726 (seconds since writing this PR).

In addition to the bug fix in the previous PR, now the sdk will default to using the user's local time zone if provided a naive time.

This can be overridden by providing a proper datetime obj with timezone information OR providing a naive time and the proper UTC offset. The datetime objects' inherit timezone will take precedent over all.

The docs are confusing, but the code doesn't lie https://github.com/python/cpython/blob/3.7/Lib/datetime.py