### PR TITLE
Fix/range param bug

### DIFF
--- a/e3db/types/search.py
+++ b/e3db/types/search.py
@@ -84,6 +84,29 @@ class Search(object):
         self.__match = p
 
     @property
+    def range_filter(self):
+        """
+        Get range parameters.
+        
+        Returns
+        -------
+        Range
+            Range object with range information
+        """
+        return self.__range
+
+    @range_filter.setter
+    def range_filter(self, r):
+        """
+        Set range parameters.
+
+        Returns
+        -------
+        None
+        """
+        self.__range = r
+
+    @property
     def excludes(self):
         """
         Get list of Params on which to exclude.
@@ -345,7 +368,7 @@ class Search(object):
         self.append_exclude(e)
         return self
     
-    def range(self, key="CREATED", format="Unix", zone="UTC", zone_offset=None, start=None, end=None):
+    def range(self, key="CREATED", start=None, end=None, zone_offset=None):
         """
         Public Method to filter search based on time the E3DB record was created or last modified.
 
@@ -354,35 +377,41 @@ class Search(object):
         key : str, optional
             "CREATED|MODIFIED" (the default is "CREATED")
 
-        format : str, optional
-            Currently is not a supported parameter (the default is "Unix")
-
-        zone : str, optional
-            Since python time objects are naive or zone-agnostic, this will attempt to append
-            the proper timezone information to the time object for the query.
-            Currently supported are:
-                "PST":"-08:00", "MST":"-07:00", "CST":"-06:00", "EST":"-05:00", "UTC":"+00:00"
-                (the default is "UTC" if the proper timezone cannot be found, which represents +00:00)
-
-        zone_offset : str, optional
-            If provided this offset will be used over zone.
-            Accepts the format "[+|-]dd:dd"
-            (the default is None(UTC), which will attempt to use zone if provided)
-        
-        start : time, optional
-            Search only for records that come after this time 
+        start: datetime, int, optional
+            Search only for records that come after this time.
+            Accepts datetime object with and without timezone information, see zone_offset for more details.
+            OR
+            Accepts int denoting unix epoch seconds.
             (the default is None, which leaves no lower bound on the query)
         
-        end : time, optional
+        end : datetime, int, optional
             Search only for records that come before this time 
+            Accepts datetime object with and without timezone information, see zone_offset for more details.
+            OR
+            Accepts int denoting unix epoch seconds.
             (the default is None, which leaves no upper bound on the query)
-        
+
+        zone_offset : int, str, optional
+            Accepts int for provided timezone in hour difference from UTC.
+            For PST(UTC-8) provide zone_offset = -8
+            For PDT(UTC-7) provide zone_offset = -7
+
+            If datetime object has timezone information, that will be given precedence.
+            If zone_offset is provided, datetime objects, start and end append this timezone
+                ex:
+                    - input: zone_offset = -7, datetime.isoformat("T") = 2019-01-01T00:00:00Z
+                    - output: 2019-01-01T00:00:00Z-07:00
+                This option should only be used if you know you want to search 
+                for a specific time within a different timezone.
+            If zone_offset == None and tzinfo does not exist, UTC will be used by default.
+            Assumes that start and end have the same timezone information
+
         Returns
         -------
         Search
             Returns reference to self, allows for chaining of match, exclude, range methods.
         """
 
-        r = Range(key=key, format=format, zone=zone, start=start, end=end)
+        r = Range(key=key, start=start, end=end, zone_offset=zone_offset)
         self.__range = r
         return self

--- a/e3db/types/search_range.py
+++ b/e3db/types/search_range.py
@@ -1,61 +1,96 @@
+from datetime import timezone, timedelta, datetime
+import re
 
 class Range():
-    def __init__(self, key="CREATED", format="Unix", zone="UTC", zone_offset=None, start=None, end=None):
+    def __init__(self, key="CREATED", start=None, end=None, zone_offset=None):
         """
         Initialize the Range class for use in Search. This class can be manually created if needed, but 
         the Search.range() method handles the Search workflow.
+
+        Once created, modifying zone_offset will not propogate the timezone changes over to start and end.
+        If you wish to change the zone for a particular time within the same Range object, provide a datetime object
+        with zone information (tzinfo).
 
         Parameters
         ----------
         key : str, optional
             "CREATED|MODIFIED" (the default is "CREATED")
 
-        format : str, optional
-            Currently is not a supported parameter (the default is "Unix")
-
-        zone : str, optional
-            Since python time objects are naive or zone-agnostic, this will attempt to append
-            the proper timezone information to the time object for the query.
-            Currently supported are:
-                "PST":"-08:00", "MST":"-07:00", "CST":"-06:00", "EST":"-05:00", "UTC":"+00:00"
-                (the default is "UTC" if the proper timezone cannot be found, which represents +00:00)
-
-        zone_offset : str, optional
-            If provided this offset will be used over zone.
-            Accepts the format "[+|-]dd:dd"
-            (the default is None(UTC), which will attempt to use zone if provided)
-        
-        end : time, optional
-            Search only for records that come before this time 
-            (the default is None, which leaves no upper bound on the query)
-        
-        after : time, optional
-            Search only for record that come after this time 
+        start: datetime, int, optional
+            Search only for records that come after this time.
+            Accepts datetime object with and without timezone information, see zone_offset for more details.
+            OR
+            Accepts int denoting unix epoch seconds.
             (the default is None, which leaves no lower bound on the query)
+        
+        end : datetime, int, optional
+            Search only for records that come before this time 
+            Accepts datetime object with and without timezone information, see zone_offset for more details.
+            OR
+            Accepts int denoting unix epoch seconds.
+            (the default is None, which leaves no upper bound on the query)
+
+        zone_offset : int, str, optional
+            Accepts int for provided timezone in hour difference from UTC.
+            For PST(UTC-8) provide zone_offset = -8
+            For PDT(UTC-7) provide zone_offset = -7
+            and so on for valid UTC offsets...
+            For a more comprehensive list see https://en.wikipedia.org/wiki/List_of_UTC_time_offsets
+
+            If datetime object has timezone information, that will be given precedence.
+            If zone_offset is provided, datetime objects, start and end append this timezone
+                ex:
+                    - input: zone_offset = -7, datetime.isoformat("T") = 2019-01-01T00:00:00Z
+                    - output: 2019-01-01T00:00:00Z-07:00
+                This option should only be used if you know you want to search 
+                for a specific time within a different timezone.
+            If zone_offset == None and tzinfo does not exist, UTC will be used by default.
+            Assumes that start and end have the same timezone information
         
         Returns
         ----------
         None
         """
         self.__key = key
-        self.__format = format
-        self.__zone = zone
-        self.__start = start 
-        self.__end = end
-        self.zone_dict = {
-            "PST":"-08:00",
-            "MST":"-07:00",
-            "CST":"-06:00",
-            "EST":"-05:00",
-            "UTC":"+00:00"
-        } 
-        if zone_offset is not None:
-            self.__zone_offset = zone_offset
-        else:
-            self.__zone_offset = self.zone_dict.get(zone, "+00:00")
-    
+        self.zone_offset = zone_offset
+        self.start = start
+        self.end = end
+
+    @staticmethod
+    def _set_timezone(t, zone_offset_minutes=None):
+        """
+        Parameters
+        ----------
+        t : datetime
+            datetime that may need timezone information
+
+        zone_offset: int, optional
+            number denoting the offset in hours from utc
+
+        Returns
+        -------
+        datetime
+            datetime with proper timezone information
+        """
+        if t.tzinfo is not None:
+            return t
+        if zone_offset_minutes is not None:
+            return t.replace(tzinfo=timezone(timedelta(minutes=zone_offset_minutes)))
+        return t.replace(tzinfo=timezone(timedelta(hours=0)))
+
     @property
     def end(self):
+        """
+        Get the end time as datetime object
+
+        Returns
+        -------
+        datetime
+            end time for query.
+        """
+        return self.__end
+    
+    def end_formatted(self):
         """
         Get the end time with time zone information appended as a string
 
@@ -66,8 +101,8 @@ class Range():
         """
         if self.__end is None:
             return None
-        return self.__end.isoformat("T") + self.__zone_offset
-    
+        return self.__end.isoformat("T")
+
     @end.setter
     def end(self, t):
         """
@@ -83,9 +118,30 @@ class Range():
         None
         """
         self.__end = t
+        if t is not None:
+            if isinstance(t, int):
+                utc_no_timezone = datetime.utcfromtimestamp(t)
+                utc = utc_no_timezone.replace(tzinfo=timezone(timedelta(minutes=0)))
+                self.__end = utc
+            elif isinstance(t, datetime):
+                self.__end = t
+                self.__end = Range._set_timezone(t, self.__zone_offset_minutes)
+            else:
+                raise TypeError('end time only accepts types int or datetime')
 
     @property
     def start(self):
+        """
+        Get the start time as datetime object
+
+        Returns
+        -------
+        datetime
+            start time for query.
+        """
+        return self.__start
+
+    def start_formatted(self):
         """
         Get the start time with time zone information appended as a string
 
@@ -96,7 +152,7 @@ class Range():
         """
         if self.__start is None:
             return None
-        return self.__start.isoformat("T") + self.__zone_offset
+        return self.__start.isoformat("T")
 
     @start.setter
     def start(self, t):
@@ -112,38 +168,17 @@ class Range():
         -------
         None
         """
-        self.__after = t
-
-    @property
-    def zone(self):
-        """
-        Get zone of Search Range
-        
-        Returns
-        -------
-        str
-            zone value
-        """
-        return self.__zone
-
-    @zone.setter
-    def zone(self, z):
-        """
-        Set zone for Search Range. Will default to "UTC" if proper timezone cannot be found, 
-        and will override the value set in zone_offset.
-
-        Parameters
-        ----------
-        z : str
-            Proper zone parameter:
-            "PST":"-08:00", "MST":"-07:00", "CST":"-06:00", "EST":"-05:00", "UTC":"+00:00"
-
-        Returns
-        -------
-        None
-        """
-        self.zone = z
-        self.__zone_offset = self.zone_dict.get(z, "+00:00")
+        self.__start = t
+        if t is not None:
+            if isinstance(t, int):
+                utc_no_timezone = datetime.utcfromtimestamp(t)
+                utc = utc_no_timezone.replace(tzinfo=timezone(timedelta(minutes=0)))
+                self.__start = utc
+            elif isinstance(t, datetime):
+                self.__start = t
+                self.__start = Range._set_timezone(t, self.__zone_offset_minutes)
+            else:
+                raise TypeError('start time only accepts types int or datetime')
 
     @property
     def zone_offset(self):
@@ -152,7 +187,7 @@ class Range():
         
         Returns
         -------
-        str
+        int
             zone_offset value
         """
         return self.__zone_offset
@@ -161,18 +196,38 @@ class Range():
     def zone_offset(self, z):
         """
         Set zone_offset for Search Range
+        Updates start and end time to match the newly set zone IFF they are timezone naive.
 
         Parameters
         ----------
-        z : str
-            Proper zone_offset parameter:
-            Accepts the format "[+|-]dd:dd"
+        z : int
+            Accepts int for provided timezone in hour difference from UTC.
+            For PST(UTC-8) provide zone_offset = -8
+            For PDT(UTC-7) provide zone_offset = -7
+            and so on for valid UTC offsets...
+            For a more comprehensive list see https://en.wikipedia.org/wiki/List_of_UTC_time_offsets
 
         Returns
         -------
         None
         """
-        self.zone_offset = z
+        self.__zone_offset = z
+        self.__zone_offset_minutes = None
+        if z is not None:
+            if isinstance(z, int):
+                self.__zone_offset_minutes = z * 60
+            elif isinstance(z, str):
+                confirm_format = r'^[+|-]\d{2}:\d{2}$'
+                if re.search(confirm_format, z) is None:
+                    raise TypeError('a zone offset string must be in the in the format "[+|-]HH:MM"')
+
+                time_information = [int(s) for s in re.findall(r'\d+', z)]
+                self.__zone_offset_minutes = (time_information[0] * 60) + time_information[1]
+
+                if z[0] == '-':
+                    self.__zone_offset_minutes = self.__zone_offset_minutes * -1 
+            else:
+                raise TypeError('zone offset only accepts an int, denoting hours offset, or a str in the format "+HH:MM" ')
     
     @property
     def key(self):
@@ -213,8 +268,8 @@ class Range():
         """
         to_serialize = {
             "range_key": str(self.__key),
-            "before": self.end,
-            "after": self.start,
+            "before": self.end_formatted(),
+            "after": self.start_formatted(),
         }
         # remove None (JSON null) objects
         for key, value in list(to_serialize.items()):


### PR DESCRIPTION
Fixes bug where zone parameter was not passed down on creation of Search object to owned Range object.

More comprehensive rework of Range handling on the SDK side with these major tenants:
- if the user provides a timezone in their date object we use that (don't override no matter what).
- If the user provides no timezone in their date object AND no zone_offset we assume UTC.
- If the user provides no timezone in their date object AND a zone_offset we will set that for them.
     - zone offset accepts both and int (for hours offset) and a string in the format "[+|-]HH:MM"
- start and end time can be both datetime or int
     - int being the Unix Epoch time, will always have a timezone of UTC.
- zone has been deprecated and removed.
