### PR TITLE
Fix crypto reference in the readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -636,7 +636,7 @@ The NIST mode of operations will leverage:
 - ECDH over curve P-384 for public/private key exchange
 - SHA384 for hashing
 - ECDSA over curve P-384 for cryptographic signatures
-- AES265GCM for symmetric encryption operations
+- AES256GCM for symmetric encryption operations
 
 ## Documentation
 


### PR DESCRIPTION
It has come to my attention that I incorrectly documented the cryptographic primitive used for symmetric crypto in NIST mode as "AES265GCM," which does not exist. I likely did so in a hurry but want to revisit that minor error and update the reference in the README with the proper references.

As this is merely a doc change, no tests are required ;-)