### PR TITLE
Feature/fix read file

### DIFF
--- a/e3db/client.py
+++ b/e3db/client.py
@@ -1341,7 +1341,8 @@ class Client:
             destination_file_handle = open(destination_filename, 'w+')
         except IOError:
             destination_file_handle.close()
-        destination_file_handle.close()
+        else:
+            destination_file_handle.close()
 
         url = self.__get_url("v1", "storage", "files", str(record_id))
         response = requests.get(url=url, auth=self.e3db_auth)

--- a/e3db/client.py
+++ b/e3db/client.py
@@ -1337,15 +1337,8 @@ class Client:
         """
 
         # Check if destination file can be written to
-        destination_file_handle = None
-        try:
-            destination_file_handle = open(destination_filename, 'w+')
-        except IOError:
-            if destination_file_handle is not None:
-                destination_file_handle.close()
-            raise IOError("Can't write to destination file")
-        else:
-            destination_file_handle.close()
+        destination_file_handle = open(destination_filename, 'w+')
+        destination_file_handle.close()
 
         url = self.__get_url("v1", "storage", "files", str(record_id))
         response = requests.get(url=url, auth=self.e3db_auth)

--- a/e3db/client.py
+++ b/e3db/client.py
@@ -1340,7 +1340,9 @@ class Client:
         try:
             destination_file_handle = open(destination_filename, 'w+')
         except IOError:
-            destination_file_handle.close()
+            if destination_file_handle is not None:
+                destination_file_handle.close()
+            raise IOError("Can't write to destination file")
         else:
             destination_file_handle.close()
 

--- a/e3db/client.py
+++ b/e3db/client.py
@@ -1337,6 +1337,7 @@ class Client:
         """
 
         # Check if destination file can be written to
+        destination_file_handle = None
         try:
             destination_file_handle = open(destination_filename, 'w+')
         except IOError:


### PR DESCRIPTION
on IOError the file handle is never opened, catching and closing just obscures underlying problem with a ValueError (when the following line is called `destination_file_handle.close()`. Leaving the open and close of the file as a preliminary check on future work.