### PR TITLE
Add signing key fields to config and client objects

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,7 +79,9 @@ config = e3db.Config(
     api_key_id,
     api_secret,
     public_key,
-    private_key
+    private_key,
+    public_signing_key,
+    private_signing_key
 )
 
 # Optionally, if you want to save this Configuration to disk, do the following:
@@ -108,7 +110,9 @@ config = e3db.Config(
     os.environ["api_key_id"],
     os.environ["api_secret"],
     os.environ["public_key"],
-    os.environ["private_key"]
+    os.environ["private_key"],
+    os.environ["public_signing_key"],
+    os.environ["private_signing_key"]
 )
 
 # Pass the configuration when building a new client instance.
@@ -252,7 +256,9 @@ config = e3db.Config(
     os.environ["api_key_id"],
     os.environ["api_secret"],
     os.environ["public_key"],
-    os.environ["private_key"]
+    os.environ["private_key"],
+    os.environ["public_signing_key"],
+    os.environ["private_signing_key"]
 )
 
 client = e3db.Client(config())

--- a/e3db/client.py
+++ b/e3db/client.py
@@ -1,4 +1,5 @@
 from .auth import E3DBAuth
+from .tsv1_auth import E3DBTSV1Auth
 import os
 if 'CRYPTO_SUITE' in os.environ and os.environ['CRYPTO_SUITE'] == 'NIST':
     from .nist_crypto import NistCrypto as Crypto
@@ -41,7 +42,10 @@ class Client:
         self.client_id = config['client_id']
         self.public_key = config['public_key']
         self.private_key = config['private_key']
+        self.public_signing_key = config['public_signing_key']
+        self.private_signing_key = config['private_signing_key']
         self.e3db_auth = E3DBAuth(self.api_key_id, self.api_secret, self.api_url)
+        self.e3db_tsv1_auth = E3DBTSV1Auth(self.private_signing_key, self.client_id)
         self.ak_cache = {}
         if 'client_email' in config.keys():
             self.client_email = config['client_email']
@@ -763,13 +767,15 @@ class Client:
         # credentials must be json encoded in order to decode
         # properly in the Tozny Dashboard.
         credentials = {
-            'version': '1',
+            'version': '2',
             'client_id': "\"{0}\"".format(self.client_id),
             'api_key_id': "\"{0}\"".format(self.api_key_id),
             'api_secret': "\"{0}\"".format(self.api_secret),
             'client_email': "\"{0}\"".format(self.client_email),
             'public_key': "\"{0}\"".format(self.public_key),
             'private_key': "\"{0}\"".format(self.private_key),
+            'public_signing_key': "\"{0}\"".format(self.public_signing_key),
+            'private_signing_key': "\"{0}\"".format(self.private_signing_key),
             'api_url': "\"{0}\"".format(self.api_url)
         }
 

--- a/e3db/config.py
+++ b/e3db/config.py
@@ -12,7 +12,7 @@ class Config:
 
     DEFAULT_API_URL = "https://api.e3db.com"
 
-    def __init__(self, client_id, api_key_id, api_secret, public_key, private_key, client_email="", version="1", api_url=DEFAULT_API_URL):
+    def __init__(self, client_id, api_key_id, api_secret, public_key, private_key, public_signing_key, private_signing_key, client_email="", version="2", api_url=DEFAULT_API_URL):
         """
         Initialize the Config class.
 
@@ -35,12 +35,18 @@ class Config:
             Private key used for crypto operations. Base64URL encoded string of
             bytes.
 
+        public_signing_key : str
+            Public signing key used for signing operations. 
+
+        private_signing_key : str
+            Private signing key used for signing operations. 
+
         client_email : str
             Email of the client.
             Optional.
 
         version : str
-            Version of the configuration file style. Defaults to 1.
+            Version of the configuration file style. Defaults to 2.
             Optional.
 
         api_url : str
@@ -52,13 +58,18 @@ class Config:
         None
         """
 
-        self.version = version
+        if private_signing_key == "":
+            self.version = 1
+        else: 
+            self.version = version
         self.client_id = client_id
         self.api_key_id = api_key_id
         self.api_secret = api_secret
         self.client_email = client_email
         self.public_key = public_key
         self.private_key = private_key
+        self.public_signing_key = public_signing_key
+        self.private_signing_key = private_signing_key
         self.api_url = api_url
 
     def __call__(self):
@@ -83,6 +94,8 @@ class Config:
             'client_email': self.client_email,
             'public_key': self.public_key,
             'private_key': self.private_key,
+            'public_signing_key': self.public_signing_key,
+            'private_signing_key': self.private_signing_key,
             'api_url': self.api_url,
         }
 
@@ -163,6 +176,8 @@ class Config:
                 'client_email': str(self.client_email),
                 'public_key': str(self.public_key),
                 'private_key': str(self.private_key),
+                'public_signing_key': str(self.public_signing_key),
+                'private_signing_key': str(self.private_signing_key),
                 'api_url': str(self.api_url),
             }
             f.write(json.dumps(config, indent=4, separators=(',', ': ')))


### PR DESCRIPTION
There are no existing tests for reading/writing configs to file system, so matching that with the addition of signing keys unless tests are wanted.