### PR TITLE
Merge read note methods

### DIFF
--- a/e3db/client.py
+++ b/e3db/client.py
@@ -1520,11 +1520,8 @@ class Client:
             Decrypted note
         """
         auth_params['note_id'] = note_id
-        return self.__read_note(auth_params, auth_headers)
-
-    def __read_note(self, params: dict, headers: dict) -> Note:
         url = self.__get_url("v2", "storage", "notes")
-        response = requests.get(url=url, auth=self.e3db_tsv1_auth, params=params, headers=headers)
+        response = requests.get(url=url, auth=self.e3db_tsv1_auth, params=auth_params, headers=auth_headers)
         self.__response_check(response)
         note = Note.decode(response.json())
         decrypted_note = self.decrypt_note(note, self.encryption_keys.private_key)

--- a/e3db/tests/test_integration.py
+++ b/e3db/tests/test_integration.py
@@ -999,7 +999,7 @@ class TestIntegrationClient():
         # If this doesn't throw an exception during instantiation, we loaded
         # the configuration properly
         config_client = e3db.Client(read_client_config())
-        assert(config_client) is not none
+        assert(config_client) is not None
 
     def test_client_signing_keys_optional(self):
         """


### PR DESCRIPTION
Removes private `__read_note` method and puts all functionality into single `read_note`. This makes it match the style of `write_note`